### PR TITLE
feat: add Debusine Package Manager action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,105 @@
+name: Build Debian Package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Execution mode'
+        required: false
+        type: choice
+        options:
+          - upload+run
+          - upload_only
+          - run_only
+        default: 'upload+run'
+      artifact_path:
+        description: 'Path to .dsc file'
+        required: false
+        default: 'path/to/package.dsc'
+
+permissions:
+  contents: write
+  pull-requests: write
+  
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie
+      options: --user root
+    permissions:
+      pull-requests: read
+      contents: write 
+    steps:
+      - name: Install git
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y git jq yq equivs
+      - name: Checkout repository
+        uses: actions/checkout@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: .github/actions/debusine-action
+      - name: Validate inputs
+        run: |
+          if [ -z "${{ secrets.DEBUSINE_TOCKEN }}" ]; then
+            echo "::error::DEBUSINE_TOCKEN secret is not set"
+            exit 1
+          fi
+
+      - name: Generate test package
+        run: |
+          set -euo pipefail
+          cd /tmp
+          equivs-build -s /dev/null
+          DSC_FILE=$(ls equivs-dummy_*.dsc | head -n1)
+          echo "TEST_DSC_PATH=/tmp/${DSC_FILE}" >> $GITHUB_ENV
+
+      - name: Run Debusine Package Manager
+        id: run-debusine
+        uses: ./.github/actions/debusine-action
+        with:
+          mode: 'upload+run'
+          debusine_token: ${{ secrets.DEBUSINE_TOCKEN }}
+          artifact_path: ${{ env.TEST_DSC_PATH }}
+          debusine_server: 'test.debusine.qualcomm.com'
+          debusine_scope: 'qualcomm'
+          workspace: 'dev'
+          workflow_name: 'sbuild-only'
+          runtime_parameters: |
+            codename: trixie
+
+      - name: Set output variables
+        run: |
+          set -x
+          WORKFLOW_ID="${{ steps.run-debusine.outputs.workflow_id }}"
+          ARTIFACT_ID="${{ steps.run-debusine.outputs.artifact_id }}"
+          WORKFLOW_URL="${{ steps.run-debusine.outputs.workflow_url }}"
+          
+          echo "workflow_id=${WORKFLOW_ID:-N/A}" >> $GITHUB_OUTPUT
+          echo "artifact_id=${ARTIFACT_ID:-N/A}" >> $GITHUB_OUTPUT
+          echo "workflow_url=${WORKFLOW_URL:-N/A}" >> $GITHUB_OUTPUT
+          
+      - name: Display outputs (from composite)
+        run: |
+          set -x
+          echo "Workflow ID:   ${{ steps.run-debusine.outputs.workflow_id }}"
+          echo "Artifact ID:   ${{ steps.run-debusine.outputs.artifact_id }}"
+          echo "Workflow URL:  ${{ steps.run-debusine.outputs.workflow_url }}"
+
+      - name: Run tests
+        env:
+          WORKFLOW_ID:  ${{ steps.run-debusine.outputs.workflow_id }}
+          ARTIFACT_ID:  ${{ steps.run-debusine.outputs.artifact_id }}
+          WORKFLOW_URL: ${{ steps.run-debusine.outputs.workflow_url }}
+        working-directory: .github/actions/debusine-action
+        run: |
+          set -x
+          chmod +x tests/debusine-trigger-test.sh
+          ./tests/debusine-trigger-test.sh

--- a/README.md
+++ b/README.md
@@ -1,47 +1,137 @@
-**After repository creation:**
-- [ ] Update this `README.md`. Update the Project Name, description, and all sections. Remove this checklist.
-- [ ] If required, update `LICENSE.txt` and the License section with your project's approved license
-- [ ] Search this repo for "REPLACE-ME" and update all instances accordingly
-- [ ] Update `CONTRIBUTING.md` as needed
-- [ ] Review the workflows in `.github/workflows`, updating as needed. See https://docs.github.com/en/actions for information on what these files do and how they work.
-- [ ] Review and update the suggested Issue and PR templates as needed in `.github/ISSUE_TEMPLATE` and `.github/PULL_REQUEST_TEMPLATE`
+# Debusine Package Manager Action
 
-# Project Name
+A GitHub Actions composite action that automates uploading Debian source packages and triggering Debusine workflows.
 
-*\<update with your project name and a short description\>*
+---
 
-Project that does ... implemented in ... runs on Qualcomm® *\<processor\>*
+## Overview
 
-## Branches
+This action wraps three sub-actions into a single configurable step:
 
-**main**: Primary development branch. Contributors should develop submissions based on this branch, and submit pull requests to this branch.
+| Sub-action | Purpose |
+|---|---|
+| `setup` | Installs `debusine-client` and configures authentication |
+| `import-artifact` | Uploads a `.dsc` source package to a Debusine workspace |
+| `run-workflow` | Starts a named Debusine workflow with the uploaded artifact |
 
-## Requirements
-
-List requirements to run the project, how to install them, instructions to use docker container, etc...
-
-## Installation Instructions
-
-How to install the software itself.
+---
 
 ## Usage
 
-Describe how to use the project.
+```yaml
+- name: Run Debusine Package Manager
+  uses: ./.github/actions/debusine-action
+  with:
+    mode: 'upload+run'
+    debusine_token: ${{ secrets.DEBUSINE_TOKEN }}
+    artifact_path: 'path/to/package.dsc'
+    workspace: 'developers'
+    workflow_name: 'my-workflow'
+    runtime_parameters: |
+      codename: trixie
+      lintian_backend: unshare
+```
 
-## Development
+---
 
-How to develop new features/fixes for the software. Maybe different than "usage". Also provide details on how to contribute via a [CONTRIBUTING.md file](CONTRIBUTING.md).
+## Inputs
 
-## Getting in Contact
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `mode` | No | `upload+run` | Execution mode (see below) |
+| `debusine_token` | **Yes** | — | Debusine API token |
+| `artifact_path` | No | — | Path to the `.dsc` file |
+| `workspace` | No | `developers` | Debusine workspace name |
+| `workflow_name` | No | — | Workflow name to execute |
+| `artifact_id` | No | `0` | Artifact ID (for `run_only` mode) |
+| `runtime_parameters` | No | `{}` | Runtime parameters as a YAML block |
+| `debusine_server` | No | `dev.debian.qualcomm.com` | Debusine server URL |
 
-How to contact maintainers. E.g. GitHub Issues, GitHub Discussions could be indicated for many cases. However a mail list or list of Maintainer e-mails could be shared for other types of discussions. E.g.
+### Modes
 
-* [Report an Issue on GitHub](../../issues)
-* [Open a Discussion on GitHub](../../discussions)
-* [E-mail us](mailto:REPLACE-ME@qti.qualcomm.com) for general questions
+| Mode | Runs Setup | Imports Artifact | Runs Workflow |
+|---|:---:|:---:|:---:|
+| `upload+run` | ✓ | ✓ | ✓ |
+| `upload_only` | ✓ | ✓ | — |
+| `run_only` | ✓ | — | ✓ |
 
-## License
+---
 
-*\<update with your project name and license\>*
+## Outputs
 
-*\<REPLACE-ME\>* is licensed under the [BSD-3-clause License](https://spdx.org/licenses/BSD-3-Clause.html). See [LICENSE.txt](LICENSE.txt) for the full license text.
+| Output | Description |
+|---|---|
+| `artifact_id` | ID of the uploaded artifact |
+| `workflow_id` | ID of the started workflow |
+| `workflow_url` | Direct URL to the workflow on the Debusine server |
+
+---
+
+## Example Workflow
+
+```yaml
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie
+      options: --user root
+    steps:
+      - uses: actions/checkout@main
+        with:
+          path: .github/actions/debusine-action
+
+      - uses: ./.github/actions/debusine-action
+        id: debusine
+        with:
+          mode: 'upload+run'
+          debusine_token: ${{ secrets.DEBUSINE_TOKEN }}
+          artifact_path: 'path/to/package.dsc'
+          workspace: 'developers'
+          workflow_name: 'test-sbuild-pipe'
+          runtime_parameters: |
+            codename: trixie
+            lintian_backend: unshare
+            sbuild_backend: unshare
+
+      - run: |
+          echo "Artifact ID:  ${{ steps.debusine.outputs.artifact_id }}"
+          echo "Workflow ID:  ${{ steps.debusine.outputs.workflow_id }}"
+          echo "Workflow URL: ${{ steps.debusine.outputs.workflow_url }}"
+```
+
+---
+
+## Secrets
+
+Add the following secret to your repository under **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|---|---|
+| `DEBUSINE_TOKEN` | Your Debusine API authentication token |
+
+---
+
+## Tests
+
+Tests are located in `tests/` and are executed automatically as part of the `build-test.yml` workflow.
+
+```
+tests/
+├── debusine-trigger-test.sh     # Test runner
+└── test-cases/
+    ├── setup_tests.json         # Verifies installation and config
+    ├── import_artifact_tests.json  # Verifies .dsc upload and artifact ID
+    ├── run_workflow_tests.json  # Verifies workflow start and outputs
+    └── compose_tests.json       # End-to-end output consistency checks
+```
+
+To run tests manually:
+
+```bash
+cd .github/actions/debusine-action
+ARTIFACT_ID=123 
+WORKFLOW_ID=456 
+WORKFLOW_URL=https://... 
+./tests/debusine-trigger-test.sh
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,73 @@
+name: 'Debusine Package Manager'
+description: 'Setup Debusine environment, import artifacts, and run workflows as per the mode'
+
+inputs:
+  mode:
+    description: 'Execution mode: "upload_only" (setup + import only) or run_only (setup + run workflow) "upload+run" (setup + import + run)'
+    required: false
+    default: 'upload+run'
+  debusine_token:
+    description: 'Debusine API Token'
+    required: true
+  artifact_path:
+    description: 'Path to the .dsc file'
+    required: false
+  workspace:
+    description: 'Debusine workspace name'
+    required: false
+    default: 'developers'
+  workflow_name:
+    description: 'Workflow name to execute workflow.'
+    required: false
+  artifact_id:
+    description: 'Artifact ID to use in workflow (only for run_only mode)'
+    required: false
+    default: '0'
+  runtime_parameters:
+    description: 'Runtime parameters as JSON string'
+    required: false
+    default: '{}'
+  debusine_server:
+    description: 'Debusine server URL (optional, defaults to dev.debian.qualcomm.com)'
+    required: false
+
+outputs:
+  workflow_id:
+    description: 'The started workflow ID'
+    value: ${{ steps.run-workflow.outputs.workflow_id }}
+  workflow_url:
+    description: 'The workflow URL'
+    value: ${{ steps.run-workflow.outputs.workflow_url }}
+  artifact_id:
+    description: 'The uploaded artifact ID'
+    value: ${{ steps.import-artifact.outputs.artifact_id }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Debusine Environment      
+      uses: ./.github/actions/debusine-action/setup
+      with:
+        debusine_token: ${{ inputs.debusine_token }}
+        debusine_server: ${{ inputs.debusine_server || 'dev.debian.qualcomm.com' }}
+        debusine_scope: ${{ inputs.debusine_scope || 'qualcomm' }}
+        
+    - name: Import Debian Artifact
+      id: import-artifact    
+      if: inputs.mode == 'upload_only' || inputs.mode == 'upload+run'
+      uses: ./.github/actions/debusine-action/import-artifact
+      with:
+        artifact_path: ${{ inputs.artifact_path }}
+        workspace: ${{ inputs.workspace }}
+        
+    - name: Run Debusine Workflow
+      id: run-workflow
+      if: inputs.mode == 'upload+run' || inputs.mode == 'run_only'
+      uses: ./.github/actions/debusine-action/run-workflow
+      with:
+        workflow_name: ${{ inputs.workflow_name }}
+        workspace: ${{ inputs.workspace }}
+        artifact_id: ${{ inputs.mode == 'upload+run' && steps.import-artifact.outputs.artifact_id || inputs.artifact_id }}
+        runtime_parameters: ${{ inputs.runtime_parameters }}
+        debusine_server: ${{ inputs.debusine_server || 'dev.debian.qualcomm.com' }}
+        debusine_scope: ${{ inputs.debusine_scope || 'qualcomm' }}

--- a/import-artifact/action.yml
+++ b/import-artifact/action.yml
@@ -1,0 +1,67 @@
+name: 'Import Debian Artifact'
+description: 'Upload Debian source package (.dsc) to Debusine workspace'
+
+inputs:
+  artifact_path:
+    description: 'Path to the .dsc file'
+    required: true
+  workspace:
+    description: 'Debusine workspace name'
+    required: false
+    default: 'developers'
+
+outputs:
+  artifact_id:
+    description: 'The uploaded artifact ID'
+    value: ${{ steps.extract.outputs.artifact_id }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate artifact
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Validating artifact"
+        
+        if [ ! -f "${{ inputs.artifact_path }}" ]; then
+          echo "::error::Artifact file not found: ${{ inputs.artifact_path }}"
+          exit 1
+        fi
+        
+        if [[ ! "${{ inputs.artifact_path }}" =~ \.dsc$ ]]; then
+          echo "::error::File must have .dsc extension"
+          exit 1
+        fi
+        
+        echo "::notice::Artifact validation passed"
+        echo "::endgroup::"
+
+    - name: Import artifact
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Importing artifact to Debusine"
+        
+        debusine artifact import-debian --workspace "${{ inputs.workspace }}" --yaml "${{ inputs.artifact_path }}" > artifact.yaml
+        
+        echo "::endgroup::"
+    
+    - name: Extract artifact ID
+      id: extract
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        artifact_id=$(yq -r '.artifact_id' artifact.yaml)
+        
+        if [ -z "$artifact_id" ] || [ "$artifact_id" = "null" ]; then
+          echo "::error::artifact_id not found in YAML output"
+          cat artifact.yaml
+          exit 1
+        fi
+        
+        echo "artifact_id=${artifact_id}" >> "$GITHUB_OUTPUT"
+        echo "::notice::Extracted artifact_id: ${artifact_id}"

--- a/run-workflow/action.yml
+++ b/run-workflow/action.yml
@@ -1,0 +1,105 @@
+name: 'Run Debusine Workflow'
+description: 'Execute a Debusine workflow with specified configuration'
+
+inputs:
+  workflow_name:
+    description: 'Workflow name to execute'
+    required: true
+  workspace:
+    description: 'Debusine workspace name'
+    required: false
+    default: 'developers'
+  artifact_id:
+    description: 'Artifact ID to use in workflow'
+    required: true
+  runtime_parameters:
+    description: 'Runtime parameters as YAML string'
+    required: false
+    default: ''
+  debusine_server:
+    description: 'Debusine server URL (optional, defaults to dev.debian.qualcomm.com)'
+    required: false
+    default: 'dev.debian.qualcomm.com'
+  debusine_scope:
+    description: 'Debusine API scope (optional, defaults to debusine)'
+    required: false
+    default: 'qualcomm'
+
+outputs:
+  workflow_id:
+    description: 'The started workflow ID'
+    value: ${{ steps.extract-workflow-id.outputs.workflow_id }}
+  workflow_url:
+    description: 'The workflow URL'
+    value: ${{ steps.extract-workflow-id.outputs.workflow_url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Generate workflow data file
+      shell: bash
+      env:
+        RUNTIME_PARAMS: ${{ inputs.runtime_parameters }}
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Generating workflow data file"
+        
+        DATA_FILE="/tmp/workflow-data-${{ github.run_id }}.yml"
+        
+        cat > "$DATA_FILE" <<EOF
+        source_artifact: ${{ inputs.artifact_id }}
+        EOF
+        
+        if [ -n "$RUNTIME_PARAMS" ]; then
+          echo "$RUNTIME_PARAMS" >> "$DATA_FILE"
+        fi
+        
+        echo "::notice::Generated data file:"
+        cat "$DATA_FILE"
+        
+        echo "DATA_FILE=$DATA_FILE" >> $GITHUB_ENV
+        echo "::endgroup::"
+    
+    - name: Run workflow
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Starting Debusine workflow"      
+        
+        debusine workflow start "${{ inputs.workflow_name }}" \
+          --workspace "${{ inputs.workspace }}" \
+          --data "$DATA_FILE" --yaml > workflowlog.yml
+        
+        echo "::endgroup::"
+    
+    - name: Extract workflow ID and URL
+      id: extract-workflow-id
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        workflow_id=$(yq -r '.id' workflowlog.yml)   
+        workflow_url=https://${{ inputs.debusine_server }}/${{ inputs.debusine_scope }}/${{ inputs.workspace }}/work-request/${workflow_id}
+        echo "workflow_id=${workflow_id}" >> "$GITHUB_OUTPUT"
+        echo "workflow_url=${workflow_url}" >> "$GITHUB_OUTPUT"
+        
+        echo "::notice::✓ Workflow started successfully"
+        echo "::notice::Workflow ID: #${workflow_id}"
+        [ -n "$workflow_url" ] && echo "::notice::Workflow URL: ${workflow_url}"
+        
+        {
+          echo "## 🚀 Debusine Workflow Started"
+          echo ""
+          echo "| Property | Value |"
+          echo "|----------|-------|"
+          echo "| **Workflow ID** | #${workflow_id} |"
+          echo "| **Workflow Name** | ${{ inputs.workflow_name }} |"
+          echo "| **Workspace** | ${{ inputs.workspace }} |"
+          echo "| **Artifact ID** | ${{ inputs.artifact_id }} |"          
+          echo ""
+          echo '```yaml'
+          cat "$DATA_FILE"
+          echo '```'
+        } >> $GITHUB_STEP_SUMMARY

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,0 +1,73 @@
+name: 'Setup Debusine Environment'
+description: 'Configure Debian container with debusine-client and repository access'
+
+inputs:
+  debusine_token:
+    description: 'Debusine API Token'
+    required: true
+  debusine_server:
+    description: 'Debusine server URL (optional, defaults to dev.debian.qualcomm.com)'
+    required: false
+    default: 'dev.debian.qualcomm.com'
+  debusine_scope:
+    description: 'Debusine API scope (optional, defaults to debusine)'
+    required: false
+    default: 'qualcomm'
+runs:
+  using: 'composite'
+  steps:
+    - name: Add Debusine repository
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Adding Debusine repository"
+        
+        tee /etc/apt/sources.list.d/trixie-backports.sources > /dev/null << 'EOF'
+        Types: deb 
+        URIs: http://deb.debian.org/debian 
+        Suites: trixie-backports 
+        Components: main contrib non-free non-free-firmware 
+        Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+        EOF
+
+        apt update && apt upgrade -y
+        
+        echo "::endgroup::"
+    
+    - name: Install required packages
+      shell: bash
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Installing debusine-client"
+        
+        apt install -t trixie-backports debusine-client -y
+        apt install -y git yq      
+        
+        echo "::endgroup::"
+    
+    - name: Configure debusine-client
+      shell: bash
+      env:
+        DEBUSINE_TOKEN: ${{ inputs.debusine_token }}
+      run: |
+        set -euo pipefail
+        
+        echo "::group::Configuring debusine-client"
+        
+        mkdir -p ~/.config/debusine/client
+        umask 077
+
+        cat > ~/.config/debusine/client/config.ini <<EOF
+        [General]
+        default-server = ${{ inputs.debusine_server }}
+
+        [server:${{ inputs.debusine_server }}]
+        api-url = https://${{ inputs.debusine_server }}/api
+        scope = ${{ inputs.debusine_scope }}
+        token = ${DEBUSINE_TOKEN}
+        EOF
+      
+        echo "::endgroup::"
+        echo "::notice::✓ Debusine client configured successfully"

--- a/tests/debusine-trigger-test.sh
+++ b/tests/debusine-trigger-test.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+set -euo pipefail
+
+# ─────────────────────────────────────────────
+# Debusine Action Unit Test Runner
+#
+# Usage:
+#   ./debusine-trigger-test.sh [suite1.json suite2.json ...]
+#
+# Optional env vars:
+#   WORKSPACE_DIR  - directory where artifact.yaml / workflowlog.yml live
+#                    defaults to GITHUB_WORKSPACE, then pwd
+# ─────────────────────────────────────────────
+
+TEST_CASES_DIR="$(cd "$(dirname "$0")/test-cases" && pwd)"
+
+# ── Resolve workspace (where action output files live) ────
+WORKSPACE_DIR="${WORKSPACE_DIR:-${GITHUB_WORKSPACE:-$(pwd)}}"
+echo "Workspace dir : $WORKSPACE_DIR"
+
+# ── Resolve which test suites to run ──────────
+if [ "$#" -gt 0 ]; then
+  TEST_FILES=("$@")
+else
+  mapfile -t TEST_FILES < <(find "$TEST_CASES_DIR" -name "*.json" | sort)
+fi
+
+if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+  echo "::error::No test JSON files found in $TEST_CASES_DIR"
+  exit 1
+fi
+
+# ── Global counters ───────────────────────────
+GRAND_TOTAL=0
+GRAND_PASSED=0
+GRAND_FAILED=0
+SUITE_SUMMARIES=()
+
+# ── Helper: resolve env_match expected value ──
+resolve_expected() {
+  local raw="$1"
+  if [[ "$raw" =~ ^\$[A-Z_]+$ ]]; then
+    local var_name="${raw:1}"
+    echo "${!var_name:-}"
+  else
+    echo "$raw"
+  fi
+}
+
+# ─────────────────────────────────────────────
+# Run a single test suite (JSON file)
+# ─────────────────────────────────────────────
+run_suite() {
+  local TEST_CONFIG="$1"
+
+  if [ ! -f "$TEST_CONFIG" ]; then
+    echo "::error::Test configuration file not found: $TEST_CONFIG"
+    return 1
+  fi
+
+  local SUITE_NAME SUITE_DESC TOTAL_TESTS
+  SUITE_NAME=$(jq -r '.action // "unknown"' "$TEST_CONFIG")
+  SUITE_DESC=$(jq -r '.description // ""' "$TEST_CONFIG")
+  TOTAL_TESTS=$(jq '.tests | length' "$TEST_CONFIG")
+  local PASSED=0 FAILED=0
+
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "::group::Suite: $SUITE_NAME  ($TEST_CONFIG)"
+  echo "Description : $SUITE_DESC"
+  echo "Test count  : $TOTAL_TESTS"
+  echo "Env context : ARTIFACT_ID=${ARTIFACT_ID:-<not set>}  WORKFLOW_ID=${WORKFLOW_ID:-<not set>}"
+  echo "Working dir : $WORKSPACE_DIR"
+  echo ""
+
+  for i in $(seq 0 $((TOTAL_TESTS - 1))); do
+    local TEST_NAME COMMAND EXPECTED VALIDATION_TYPE DESCRIPTION
+    TEST_NAME=$(jq -r ".tests[$i].name" "$TEST_CONFIG")
+    COMMAND=$(jq -r ".tests[$i].command" "$TEST_CONFIG")
+    EXPECTED=$(jq -r ".tests[$i].expected" "$TEST_CONFIG")
+    VALIDATION_TYPE=$(jq -r ".tests[$i].validation_type" "$TEST_CONFIG")
+    DESCRIPTION=$(jq -r ".tests[$i].description" "$TEST_CONFIG")
+
+    echo "  ┌─ Test $((i + 1))/$TOTAL_TESTS: $TEST_NAME"
+    echo "  │  Description : $DESCRIPTION"
+    echo "  │  Command     : $COMMAND"
+    echo "  │  Expect      : $EXPECTED  (type: $VALIDATION_TYPE)"
+
+    # Execute command from WORKSPACE_DIR so relative paths resolve correctly
+    local OUTPUT EXIT_CODE=0
+    OUTPUT=$(cd "$WORKSPACE_DIR" && eval "$COMMAND" 2>&1) || EXIT_CODE=$?
+
+    echo "  │  Output      : $OUTPUT"
+    echo "  │  Exit code   : $EXIT_CODE"
+
+    local RESULT="FAILED" REASON=""
+
+    case "$VALIDATION_TYPE" in
+      "regex")
+        if echo "$OUTPUT" | grep -qE "$EXPECTED"; then
+          RESULT="PASSED"
+        else
+          REASON="output did not match regex: $EXPECTED"
+        fi
+        ;;
+      "numeric")
+        if echo "$OUTPUT" | grep -qE "^[0-9]+$"; then
+          RESULT="PASSED"
+        else
+          REASON="output is not a numeric value: $OUTPUT"
+        fi
+        ;;
+      "exact")
+        if [ "$OUTPUT" = "$EXPECTED" ]; then
+          RESULT="PASSED"
+        else
+          REASON="expected '$EXPECTED', got '$OUTPUT'"
+        fi
+        ;;
+      "contains")
+        if echo "$OUTPUT" | grep -qF "$EXPECTED"; then
+          RESULT="PASSED"
+        else
+          REASON="output does not contain '$EXPECTED'"
+        fi
+        ;;
+      "env_match")
+        local RESOLVED
+        RESOLVED=$(resolve_expected "$EXPECTED")
+        if [ -z "$RESOLVED" ]; then
+          REASON="env var '$EXPECTED' is not set or empty"
+        elif [ "$OUTPUT" = "$RESOLVED" ]; then
+          RESULT="PASSED"
+        else
+          REASON="expected env value '$RESOLVED', got '$OUTPUT'"
+        fi
+        ;;
+      "exit_code")
+        if [ "$EXIT_CODE" = "$EXPECTED" ]; then
+          RESULT="PASSED"
+        else
+          REASON="expected exit code $EXPECTED, got $EXIT_CODE"
+        fi
+        ;;
+      *)
+        REASON="unknown validation type: $VALIDATION_TYPE"
+        ;;
+    esac
+
+    if [ "$RESULT" = "PASSED" ]; then
+      echo "  └─ ✓ PASSED"
+      PASSED=$((PASSED + 1))
+    else
+      echo "  └─ ✗ FAILED — $REASON"
+      FAILED=$((FAILED + 1))
+    fi
+    echo ""
+  done
+
+  echo "::endgroup::"
+
+  local RATE=0
+  [ "$TOTAL_TESTS" -gt 0 ] && RATE=$(( PASSED * 100 / TOTAL_TESTS ))
+  echo "  Suite result: $PASSED/$TOTAL_TESTS passed  ($RATE%)"
+  echo ""
+
+  GRAND_TOTAL=$((GRAND_TOTAL + TOTAL_TESTS))
+  GRAND_PASSED=$((GRAND_PASSED + PASSED))
+  GRAND_FAILED=$((GRAND_FAILED + FAILED))
+
+  local STATUS_ICON="✓"
+  [ "$FAILED" -gt 0 ] && STATUS_ICON="✗"
+  SUITE_SUMMARIES+=("| **${SUITE_NAME}** | ${TOTAL_TESTS} | ${PASSED} | ${FAILED} | ${RATE}% | ${STATUS_ICON} |")
+}
+
+# ─────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════╗"
+echo "║         Debusine Action Test Runner              ║"
+echo "╚══════════════════════════════════════════════════╝"
+echo "Suites to run: ${#TEST_FILES[@]}"
+echo ""
+
+for suite_file in "${TEST_FILES[@]}"; do
+  run_suite "$suite_file"
+done
+
+GRAND_RATE=0
+[ "$GRAND_TOTAL" -gt 0 ] && GRAND_RATE=$(( GRAND_PASSED * 100 / GRAND_TOTAL ))
+
+echo "╔══════════════════════════════════════════════════╗"
+echo "║                 FINAL RESULTS                   ║"
+echo "╚══════════════════════════════════════════════════╝"
+echo "  Total  : $GRAND_TOTAL"
+echo "  Passed : $GRAND_PASSED"
+echo "  Failed : $GRAND_FAILED"
+echo "  Rate   : $GRAND_RATE%"
+echo ""
+
+{
+  echo "## 🧪 Debusine Action Test Results"
+  echo ""
+  echo "| Suite | Total | ✓ Passed | ✗ Failed | Rate | Status |"
+  echo "|-------|-------|----------|----------|------|--------|"
+  for row in "${SUITE_SUMMARIES[@]}"; do
+    echo "$row"
+  done
+  echo ""
+  echo "---"
+  echo ""
+  echo "### Overall"
+  echo ""
+  echo "| Metric | Value |"
+  echo "|--------|-------|"
+  echo "| **Total Tests** | $GRAND_TOTAL |"
+  echo "| **Passed** | ✓ $GRAND_PASSED |"
+  echo "| **Failed** | ✗ $GRAND_FAILED |"
+  echo "| **Success Rate** | $GRAND_RATE% |"
+  echo ""
+  echo "**Artifact ID:** \`${ARTIFACT_ID:-N/A}\`"
+  echo "**Workflow ID:** \`${WORKFLOW_ID:-N/A}\`"
+  echo "**Workflow URL:** ${WORKFLOW_URL:-N/A}"
+} >> "$GITHUB_STEP_SUMMARY"
+
+if [ "$GRAND_FAILED" -eq 0 ]; then
+  echo "::notice::✓ All $GRAND_PASSED tests passed across ${#TEST_FILES[@]} suite(s)"
+  exit 0
+else
+  echo "::error::$GRAND_FAILED test(s) failed out of $GRAND_TOTAL across ${#TEST_FILES[@]} suite(s)"
+  exit 1
+fi

--- a/tests/test-cases/compose_tests.json
+++ b/tests/test-cases/compose_tests.json
@@ -1,0 +1,48 @@
+{
+  "description": "Wrapper composite action (action.yml) end-to-end tests - verifies all three sub-actions ran and outputs are consistent",
+  "action": "compose-tests",
+  "tests": [
+    {
+      "name": "all_output_files_present",
+      "command": "test -f artifact.yaml && test -f workflowlog.yml && echo 'all_present'",
+      "expected": "all_present",
+      "validation_type": "exact",
+      "description": "Verify both artifact.yaml and workflowlog.yml exist — confirms setup+import+run all executed"
+    },
+    {
+      "name": "artifact_id_and_workflow_id_both_set",
+      "command": "[ -n \"$ARTIFACT_ID\" ] && [ -n \"$WORKFLOW_ID\" ] && echo 'both_set' || echo 'missing'",
+      "expected": "both_set",
+      "validation_type": "exact",
+      "description": "Verify both ARTIFACT_ID and WORKFLOW_ID env vars are non-empty (wrapper passed outputs correctly)"
+    },
+    {
+      "name": "workflow_url_references_artifact",
+      "command": "echo $WORKFLOW_URL | grep -qE '^https://' && echo 'valid' || echo 'invalid'",
+      "expected": "valid",
+      "validation_type": "exact",
+      "description": "Verify WORKFLOW_URL is a valid https URL produced by the wrapper"
+    },
+    {
+      "name": "artifact_id_propagated_to_workflow",
+      "command": "cat /tmp/workflow-data-*.yml | yq -r '.source_artifact'",
+      "expected": "$ARTIFACT_ID",
+      "validation_type": "env_match",
+      "description": "Verify wrapper correctly passed import-artifact output artifact_id into run-workflow as source_artifact"
+    },
+    {
+      "name": "workflow_id_consistent_across_outputs",
+      "command": "yq -r '.id' workflowlog.yml",
+      "expected": "$WORKFLOW_ID",
+      "validation_type": "env_match",
+      "description": "Verify WORKFLOW_ID env var matches the id in workflowlog.yml — confirms wrapper output wiring is correct"
+    },
+    {
+      "name": "artifact_id_consistent_across_outputs",
+      "command": "yq -r '.artifact_id' artifact.yaml",
+      "expected": "$ARTIFACT_ID",
+      "validation_type": "env_match",
+      "description": "Verify ARTIFACT_ID env var matches artifact_id in artifact.yaml — confirms wrapper output wiring is correct"
+    }
+  ]
+}

--- a/tests/test-cases/import_artifact_tests.json
+++ b/tests/test-cases/import_artifact_tests.json
@@ -1,0 +1,55 @@
+{
+  "description": "Import artifact action (import-artifact/action.yml) - verifies .dsc upload and artifact ID extraction",
+  "action": "import-artifact",
+  "tests": [
+    {
+      "name": "artifact_yaml_exists",
+      "command": "test -f artifact.yaml && echo 'exists'",
+      "expected": "exists",
+      "validation_type": "exact",
+      "description": "Verify artifact.yaml output file was created by debusine artifact import-debian"
+    },
+    {
+      "name": "artifact_yaml_not_empty",
+      "command": "test -s artifact.yaml && echo 'non-empty'",
+      "expected": "non-empty",
+      "validation_type": "exact",
+      "description": "Verify artifact.yaml is not empty"
+    },
+    {
+      "name": "artifact_yaml_has_artifact_id_key",
+      "command": "yq -r 'has(\"artifact_id\")' artifact.yaml",
+      "expected": "^true$",
+      "validation_type": "regex",
+      "description": "Verify artifact.yaml contains the artifact_id key"
+    },
+    {
+      "name": "artifact_yaml_id_is_numeric",
+      "command": "yq -r '.artifact_id' artifact.yaml",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify artifact_id value inside artifact.yaml is a valid positive integer"
+    },
+    {
+      "name": "artifact_id_env_is_numeric",
+      "command": "echo $ARTIFACT_ID",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify extracted ARTIFACT_ID env var is a valid positive integer greater than zero"
+    },
+    {
+      "name": "debusine_artifact_show_exit_code",
+      "command": "debusine artifact show --yaml $ARTIFACT_ID > /dev/null 2>&1; echo $?",
+      "expected": "^0$",
+      "validation_type": "regex",
+      "description": "Verify debusine artifact show exits with code 0 (artifact exists on server)"
+    },
+    {
+      "name": "debusine_artifact_show_id_matches",
+      "command": "debusine artifact show --yaml $ARTIFACT_ID 2>&1 | yq -r '.id'",
+      "expected": "$ARTIFACT_ID",
+      "validation_type": "env_match",
+      "description": "Verify artifact ID returned by server matches the imported ARTIFACT_ID"
+    }
+  ]
+}

--- a/tests/test-cases/run_workflow_tests.json
+++ b/tests/test-cases/run_workflow_tests.json
@@ -1,0 +1,55 @@
+{
+  "description": "Run workflow action (run-workflow/action.yml) - verifies workflow start, ID and URL extraction",
+  "action": "run-workflow",
+  "tests": [
+    {
+      "name": "workflowlog_has_id_key",
+      "command": "yq -r 'has(\"id\")' workflowlog.yml",
+      "expected": "^true$",
+      "validation_type": "regex",
+      "description": "Verify workflowlog.yml contains the id key"
+    },
+    {
+      "name": "workflowlog_id_is_numeric",
+      "command": "yq -r '.id' workflowlog.yml",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify id value inside workflowlog.yml is a valid positive integer"
+    },
+    {
+      "name": "workflow_id_env_is_numeric",
+      "command": "echo $WORKFLOW_ID",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify extracted WORKFLOW_ID env var is a valid positive integer greater than zero"
+    },
+    {
+      "name": "workflow_url_env_set",
+      "command": "echo $WORKFLOW_URL",
+      "expected": "^https://",
+      "validation_type": "regex",
+      "description": "Verify WORKFLOW_URL env var is set and starts with https://"
+    },
+    {
+      "name": "workflow_url_contains_workflow_id",
+      "command": "echo $WORKFLOW_URL | grep -o \"${WORKFLOW_ID}\"",
+      "expected": "^[0-9]+$",
+      "validation_type": "regex",
+      "description": "Verify WORKFLOW_URL contains the WORKFLOW_ID"
+    },
+    {
+      "name": "data_file_created",
+      "command": "ls /tmp/workflow-data-*.yml 2>/dev/null | wc -l | xargs",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify workflow data file was created in /tmp by run-workflow action"
+    },
+    {
+      "name": "debusine_work_request_exit_code",
+      "command": "debusine work-request show --yaml $WORKFLOW_ID > /dev/null 2>&1; echo $?",
+      "expected": "^0$",
+      "validation_type": "regex",
+      "description": "Verify workflow/work-request exists on server (exit code 0)"
+    }
+  ]
+}

--- a/tests/test-cases/setup_tests.json
+++ b/tests/test-cases/setup_tests.json
@@ -1,0 +1,104 @@
+{
+  "description": "Setup action (setup/action.yml) - verifies debusine-client installation and configuration",
+  "action": "setup",
+  "tests": [
+    {
+      "name": "debusine_installed",
+      "command": "which debusine",
+      "expected": "debusine",
+      "validation_type": "contains",
+      "description": "Verify debusine CLI binary is installed and in PATH"
+    },
+    {
+      "name": "debusine_version",
+      "command": "debusine --version 2>&1 | head -n1",
+      "expected": "debusine 0\\.1[0-9]\\.[0-9]+",
+      "validation_type": "regex",
+      "description": "Verify debusine CLI version is accessible and returns valid semver"
+    },
+    {
+      "name": "debusine_artifact_subcommand",
+      "command": "debusine artifact -h 2>&1 | grep -c 'import-debian'",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify debusine artifact subcommand includes import-debian"
+    },
+    {
+      "name": "debusine_workflow_subcommand",
+      "command": "debusine workflow -h 2>&1 | grep -c 'start'",
+      "expected": "^[1-9][0-9]*$",
+      "validation_type": "regex",
+      "description": "Verify debusine workflow subcommand includes start"
+    },
+    {
+      "name": "debusine_help_exit_code",
+      "command": "debusine -h > /dev/null 2>&1; echo $?",
+      "expected": "^0$",
+      "validation_type": "regex",
+      "description": "Verify debusine -h exits with code 0"
+    },
+    {
+      "name": "yq_installed",
+      "command": "yq --version 2>&1 | head -n1",
+      "expected": "yq",
+      "validation_type": "contains",
+      "description": "Verify yq is installed (required for YAML parsing in actions)"
+    },
+    {
+      "name": "git_installed",
+      "command": "git --version 2>&1 | head -n1",
+      "expected": "^git version",
+      "validation_type": "regex",
+      "description": "Verify git is installed"
+    },
+    {
+      "name": "config_file_exists",
+      "command": "test -f ~/.config/debusine/client/config.ini && echo 'exists'",
+      "expected": "exists",
+      "validation_type": "exact",
+      "description": "Verify debusine client config.ini file was created"
+    },
+    {
+      "name": "config_has_general_section",
+      "command": "grep -c '\\[General\\]' ~/.config/debusine/client/config.ini",
+      "expected": "^1$",
+      "validation_type": "regex",
+      "description": "Verify config.ini contains [General] section"
+    },
+    {
+      "name": "config_has_default_server",
+      "command": "grep 'default-server' ~/.config/debusine/client/config.ini | awk -F'=' '{print $2}' | xargs",
+      "expected": "^[a-zA-Z0-9._-]+$",
+      "validation_type": "regex",
+      "description": "Verify config.ini has a valid default-server entry"
+    },
+    {
+      "name": "config_has_api_url",
+      "command": "grep 'api-url' ~/.config/debusine/client/config.ini | awk -F'= ' '{print $2}' | xargs",
+      "expected": "^https://",
+      "validation_type": "regex",
+      "description": "Verify config.ini api-url starts with https://"
+    },
+    {
+      "name": "config_has_scope",
+      "command": "grep 'scope' ~/.config/debusine/client/config.ini | awk -F'= ' '{print $2}' | xargs",
+      "expected": "^[a-zA-Z0-9_-]+$",
+      "validation_type": "regex",
+      "description": "Verify config.ini has a non-empty scope value"
+    },
+    {
+      "name": "config_has_token",
+      "command": "grep 'token' ~/.config/debusine/client/config.ini | awk -F'= ' '{print $2}' | xargs",
+      "expected": "^[A-Za-z0-9]+$",
+      "validation_type": "regex",
+      "description": "Verify config.ini has a non-empty token value"
+    },
+    {
+      "name": "config_file_permissions",
+      "command": "stat -c '%a' ~/.config/debusine/client/config.ini",
+      "expected": "^6[04]0$",
+      "validation_type": "regex",
+      "description": "Verify config.ini has secure file permissions (600 or 640)"
+    }
+  ]
+}


### PR DESCRIPTION
Introduce a composite GitHub Action that automates Debian source package uploads and Debusine workflow execution.

The action is split into three focused sub-actions:
- setup: installs debusine-client and writes config.ini
- import-artifact: uploads a .dsc file and extracts the artifact ID from YAML output
- run-workflow: starts a named workflow with the artifact and extracts workflow ID and URL

A top-level composite action (action.yml) wires all three together and exposes three execution modes:
- upload+run: full pipeline (default)
- upload_only: setup + import only
- run_only: setup + run with an existing artifact ID

Also includes:
- build-test.yml CI workflow using debian:trixie container
- JSON-driven test suites for each sub-action and end-to-end
- bash test runner with regex, exact, contains, and env_match validation types and a Markdown step summary output
- README with usage, inputs/outputs, modes, and test docs