### PR TITLE
Add MVP reusable workflow

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -1,0 +1,215 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+name: Debusine CI
+
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        description: Where the packaging will land (or for dailies, has landed)
+        type: string
+        required: true
+      source_ref:
+        description: What packaging to test. Defaults to using github.ref.
+        type: string
+        required: false
+      release:
+        description: Run release step
+        type: boolean
+        required: true
+        default: true
+      job_index:
+        # This is used to generate a unique Debusine child workspace name for
+        # each expansion of the matrix
+        description: Uniquely identifying index for matrix strategies
+        type: string
+        required: false
+        default: "0"
+    secrets:
+      DEBUSINE_USER:
+        required: true
+      DEBUSINE_TOKEN:
+        required: true
+      DEBUSINE_RELEASE_TOKEN:
+        required: true
+
+# Release runs for the same branch share a group (preventing concurrent
+# releases), while non-release runs get unique groups (allowing concurrent
+# execution)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.target_branch }}-${{ inputs.release && 'release' || github.run_id }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    outputs:
+      suite: ${{ steps.map_suite.outputs.suite }}
+      source_ref: ${{ steps.determine_checkout_ref.outputs.source_ref }}
+      workspace: ${{ steps.build.outputs.workspace }}
+      srcpkg_name: ${{ steps.build.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.build.outputs.srcpkg_version }}
+    steps:
+      - id: map_suite
+        name: Map branch to suite
+        uses: actions/github-script@v9
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        with:
+          script: |
+            const suiteMap = {
+              "qcom/debian/latest": "forky",
+              "qcom/debian/trixie": "trixie",
+            };
+
+            const targetBranch = process.env.TARGET_BRANCH;
+            const suite = suiteMap[targetBranch];
+
+            if (!suite) {
+              core.setFailed(`Unknown target branch: ${targetBranch}. Valid branches are: ${Object.keys(suiteMap).join(', ')}`);
+              return;
+            }
+
+            core.setOutput('suite', suite);
+            core.info(`Mapped branch '${targetBranch}' to suite '${suite}'`);
+      - id: determine_checkout_ref
+        name: Determine the ref of the packaging to build
+        uses: actions/github-script@v9
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        with:
+          script: |
+            const sourceRef = process.env.SOURCE_REF;
+            let ref;
+            if (sourceRef) {
+              // Explicit override from caller (e.g. schedule + matrix)
+              ref = sourceRef;
+            } else if (context.eventName === 'pull_request') {
+              // PR: use head SHA, not refs/pull/*/merge
+              ref = context.payload.pull_request.head.sha;
+            } else {
+              // push / workflow_dispatch / schedule default
+              ref = context.ref;
+            }
+            core.setOutput('source_ref', ref);
+            core.info(`Using source_ref '${ref}'`);
+      - uses: actions/checkout@v6
+        with:
+          # Using the parent directory for Debian build artifacts is problematic, for example breaking actions/upload-artifact:
+          # https://github.com/actions/upload-artifact/issues/176
+          path: srcpkg
+          ref: ${{ steps.determine_checkout_ref.outputs.source_ref }}
+      - uses: actions/checkout@v6
+        with:
+          repository: qualcomm-linux/debusine-action
+          ref: main
+          path: debusine-action
+      - id: build
+        name: Build
+        env:
+          RELEASE: ${{ inputs.release }}
+          SUITE: ${{ steps.map_suite.outputs.suite }}
+          GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          JOB_INDEX: ${{ inputs.job_index }}
+          DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
+          DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE}}
+          DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+        run: |
+          set -ex
+
+          debusine-action/lib/prepare-incus
+          debusine-action/lib/prepare-debusine
+
+          if [ "$RELEASE" = "true" ]; then
+            echo "::group::Prepare release"
+            sudo apt-get install --update --no-install-recommends -y devscripts dpkg-dev git-buildpackage
+            SUITE="$SUITE" debusine-action/lib/prepare-release
+            echo "::endgroup::"
+          fi
+
+          echo "::group::Generate source package"
+          sudo apt-get install --update --no-install-recommends -y devscripts dctrl-tools
+          SUITE="$SUITE" debusine-action/lib/generate-source-package
+          dcmd sudo incus file push *.changes debusine/root/
+          echo "::endgroup::"
+
+          sudo incus exec debusine env \
+            "GITHUB_REPOSITORY_ID=$GITHUB_REPOSITORY_ID" \
+            "GITHUB_RUN_ID=$GITHUB_RUN_ID" \
+            "GITHUB_RUN_ATTEMPT=$GITHUB_RUN_ATTEMPT" \
+            "JOB_INDEX=$JOB_INDEX" \
+            "DEBUSINE_HOST=$DEBUSINE_HOST" \
+            "DEBUSINE_SCOPE=$DEBUSINE_SCOPE" \
+            "DEBUSINE_USER=$DEBUSINE_USER" \
+            "DEBUSINE_TOKEN=$DEBUSINE_TOKEN" \
+            "SUITE=$SUITE" \
+            debusine-action/lib/build
+          sudo incus exec debusine cat output >> "$GITHUB_OUTPUT"
+      - name: Note Debusine workspace URL
+        env:
+          WORKSPACE_URL: ${{ steps.build.outputs.url }}
+        run: |
+          echo "Debusine Workspace URL: $WORKSPACE_URL" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload release bundle
+        if: ${{ inputs.release }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-bundle
+          path: release.bundle
+          if-no-files-found: error
+
+  release:
+    name: Release
+    if: ${{ inputs.release }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: Production
+    permissions:
+      contents: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Using the parent directory for Debian build artifacts is problematic, for example breaking actions/upload-artifact:
+          # https://github.com/actions/upload-artifact/issues/176
+          path: srcpkg
+          ref: ${{ needs.build.outputs.source_ref }}
+      - uses: actions/checkout@v6
+        with:
+          repository: qualcomm-linux/debusine-action
+          ref: main
+          path: debusine-action
+      - name: Download release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: release-bundle
+      - name: Release
+        env:
+          DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
+          DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE}}
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
+          DEBUSINE_CI_WORKSPACE: ${{ needs.build.outputs.workspace }}
+          SRCPKG_NAME: ${{ needs.build.outputs.srcpkg_name }}
+          SRCPKG_VERSION: ${{ needs.build.outputs.srcpkg_version}}
+          SUITE: ${{ needs.build.outputs.suite }}
+        run: |
+          set -ex
+
+          sudo apt-get install --update --no-install-recommends -y devscripts dpkg-dev python3
+          debusine-action/lib/prepare-incus
+          debusine-action/lib/prepare-debusine
+          sudo incus exec debusine env \
+            "DEBUSINE_HOST=$DEBUSINE_HOST" \
+            "DEBUSINE_SCOPE=$DEBUSINE_SCOPE" \
+            "DEBUSINE_TOKEN=$DEBUSINE_TOKEN" \
+            "DEBUSINE_CI_WORKSPACE=$DEBUSINE_CI_WORKSPACE" \
+            "SRCPKG_NAME=$SRCPKG_NAME" \
+            "SRCPKG_VERSION=$SRCPKG_VERSION" \
+            "SUITE=$SUITE" \
+            debusine-action/lib/release
+
+          debusine-action/lib/push-release

--- a/lib/build
+++ b/lib/build
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -eux
+set -o pipefail
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Send a source package to Debusine for building and wait for build completion
+
+# Run inside the container created with `debusine-action/lib/prepare-debusine`
+
+# Dependencies:
+#   `debusine` incus container (Debusine will be configured)
+
+# Inputs:
+#   GITHUB_REPOSITORY_ID
+#   GITHUB_RUN_ID
+#   GITHUB_RUN_ATTEMPT
+#   JOB_INDEX
+#   DEBUSINE_HOST
+#   DEBUSINE_SCOPE
+#   DEBUSINE_TOKEN
+#   SUITE
+#   .dsc file in current directory
+
+# Outputs:
+#   Output file `output` suitable for $GITHUB_OUTPUT containing `workspace`
+
+echo "::group::Build in Debusine"
+
+child_ci_suffix=gh-${GITHUB_REPOSITORY_ID}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${JOB_INDEX}
+workspace="ci-${child_ci_suffix}"
+
+mkdir -p ~/.config/debusine/client
+( umask 077; cat > ~/.config/debusine/client/config.ini <<EOF
+[General]
+default-server = default
+
+[server:default]
+api-url = https://${DEBUSINE_HOST}/api
+scope = ${DEBUSINE_SCOPE}
+token = ${DEBUSINE_TOKEN}
+default-workspace = $workspace
+EOF
+)
+
+workflow_id=$(echo "suffix: $child_ci_suffix"|debusine workflow start -w ci --yaml create-child-workspace|yq -r .id)
+debusine-action/lib/poll_workflow.py "$workflow_id"
+debusine archive suite create --architecture all --architecture amd64 --architecture arm64 ${SUITE}
+debusine workflow-template create debian_pipeline debian-pipeline <<END
+static_parameters:
+  vendor: debian
+  sbuild_environment_variant: buildd
+  # We do want to enable debusine QA, but to get going for now, defer this for later
+  # enable_check_installability: false this one is documented but not recognised
+  enable_autopkgtest: false
+  enable_lintian: false
+  enable_piuparts: false
+  enable_blhc: false
+  codename: $SUITE
+  suite: $SUITE@debian:suite
+runtime_parameters:
+  source_artifact: any
+END
+artifact_id=$(debusine artifact import-debian --yaml *.dsc|yq -r .artifact_id)
+workflow_id=$(echo "source_artifact: ${artifact_id}@artifacts"|debusine workflow start --yaml debian-pipeline|yq -r .id)
+debusine-action/lib/poll_workflow.py "$workflow_id"
+
+echo "workspace=$workspace" > output
+echo "url=https://${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${workspace}/" >> output
+echo "::endgroup::"

--- a/lib/generate-apt-config
+++ b/lib/generate-apt-config
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Generates the files in the current directory for dropping into the target
+# system:
+
+# Run on the host
+
+# Dependencies:
+#   ca-certificates and curl packages: when you run this script
+#   ca-certificates: on the target system since HTTPS is used
+
+# Inputs:
+#   DEBUSINE_HOST
+#   DEBUSINE_SCOPE
+#   DEBUSINE_USER
+#   DEBUSINE_TOKEN
+#   DEBUSINE_WORKSPACE
+#   SUITE
+
+# Outputs:
+#   debusine-ci.sources: to drop into /etc/apt/sources.list.d/
+#   debusine-ci-auth.conf: to drop into /etc/apt/auth.conf.d/
+
+public_key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${DEBUSINE_WORKSPACE}/signing-keys.asc"|sed -e 's/^$/./;s/^/ /')
+cat > debusine-ci.sources <<END
+Types: deb deb-src
+URIs: https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${DEBUSINE_WORKSPACE}/
+Suites: ${SUITE}
+Components: main
+Signed-By:
+${public_key}
+END
+( umask 077; cat > debusine-ci-auth.conf <<END
+machine deb.${DEBUSINE_HOST}
+login ${DEBUSINE_USER}
+password ${DEBUSINE_TOKEN}
+END
+)

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Convert a source tree from a git repository into a Debian source package.
+
+# Usually this would be just `dpkg-buildpackage -S`, but we have some packages
+# that require more specialist pre-build steps. The required steps should be as
+# straightforward and aligned with Debian Developer expectations as we can
+# achieve. This script should contain all the knowledge required to build
+# source packages from these exceptional source trees.
+
+# The `dpkg-buildpackage -S` step is specifically done inside a container that
+# matches the target suite in case there are nuances that break when not done
+# this way.
+
+# This script should run from a host system with Incus available. It will do
+# the work inside a container as needed.
+
+# Run on the host
+
+# Dependencies:
+#     incus (configured)
+#     devscripts
+#     dctrl-tools
+
+# Inputs:
+#     $PWD/srcpkg/: checked out source tree
+#     $SUITE: target suite to prepare in (eg. 'trixie')
+
+# Outputs:
+#     Parent directory: .changes files for source package together with all
+#         referenced files
+#     $GITHUB_OUTPUT (append): srcpkg_name, srcpkg_version
+
+# A couple of things we might want to implement in the future:
+# 1. Run as a normal user, not root
+# 2. Install build dependencies before building the source package
+
+echo "::group::Prepare source package"
+sudo incus launch "images:debian/$SUITE" srcbuild
+sudo incus file push -r srcpkg srcbuild/root/
+sudo incus exec srcbuild -- sh - <<END
+set -ex
+apt-get install --update --no-install-recommends -y dpkg-dev
+cd srcpkg
+dpkg-buildpackage -S -d -nc
+END
+changes_file=$(sudo incus exec srcbuild -- sh -c 'echo *.changes')
+sudo incus file pull "srcbuild/root/$changes_file" .
+for another_file in $(dcmd --no-changes echo "$changes_file"); do
+    sudo incus file pull "srcbuild/root/$another_file" .
+done
+
+cat >> "$GITHUB_OUTPUT" <<END
+srcpkg_name=$(grep-dctrl -nsSource . *.dsc)
+srcpkg_version=$(grep-dctrl -nsVersion . *.dsc)
+END
+echo "::endgroup::"

--- a/lib/next_qcom_version
+++ b/lib/next_qcom_version
@@ -1,0 +1,1 @@
+next_qcom_version.py

--- a/lib/next_qcom_version.py
+++ b/lib/next_qcom_version.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python3
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""Helpers for debchange-style qcom version increments.
+
+Debian version strings have the form ``[epoch:]upstream_version[-debian_revision]``;
+see Debian Policy §5.6.12:
+https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-version
+
+This module implements the subset of ``debchange -i`` behaviour that is specific
+to Ubuntu vendor versioning, but replaces the substring ``ubuntu`` with
+``qcom``. The function operates on a full Debian package version string and
+returns the incremented version string.
+"""
+
+# Written by QGenie
+
+from __future__ import annotations
+
+import re
+import sys
+
+_INCREMENTABLE_RE = re.compile(r"^(.*?)([a-yA-Y][a-zA-Z]*|\d+)([+~])?$", re.IGNORECASE)
+_NATIVE_QCOM_RE = re.compile(r"^(.*?)(\d+)$", re.IGNORECASE)
+
+
+def increment_qcom_version(version: str) -> str:
+    """Return the next debchange-style qcom version for ``version``.
+
+    The behaviour matches the ``dch -i`` Ubuntu-specific path in
+    ``scripts/debchange.pl``, except that ``qcom`` is used where Ubuntu uses
+    ``ubuntu``:
+
+    * if the version does not already end in a qcom/ppa derivative suffix,
+      append ``qcom1``;
+    * if the version carries a ``build`` suffix, drop that suffix before adding
+      ``qcom1``;
+    * for a native package ending in ``qcom`` with no trailing digit, bump the
+      numeric tail immediately before ``qcom`` and keep the ``qcom`` suffix;
+    * otherwise, increment the final alphanumeric component the same way
+      ``dch -i`` does.
+
+    Args:
+        version: A Debian package version string.
+
+    Returns:
+        The incremented Debian package version string.
+
+    Raises:
+        ValueError: If the version cannot be parsed according to the subset of
+            Debian version syntax handled here, or when the version has a
+            contradictory native/Non-native qcom form analogous to debchange's
+            fatal error.
+    """
+    # Check for ~ppa versions - increment the debian revision before ~ppa
+    ppa_match = re.match(r"^(.*?)(\d+)(~ppa.*)$", version)
+    if ppa_match:
+        # For ~ppa versions, increment the debian revision and keep the ppa suffix
+        prefix, debian_rev, ppa_suffix = ppa_match.groups()
+        return f"{prefix}{int(debian_rev) + 1}{ppa_suffix}"
+
+    # Check for ~bpo versions - increment the bpo number
+    bpo_match = re.match(r"^(.*?)(~bpo)(\d+)(.*)$", version)
+    if bpo_match:
+        # For ~bpo versions, increment the number after bpo
+        prefix, bpo_type, bpo_num, suffix = bpo_match.groups()
+        return f"{prefix}{bpo_type}{int(bpo_num) + 1}{suffix}"
+
+    match = _INCREMENTABLE_RE.match(version)
+    if not match:
+        raise ValueError(f"unable to parse Debian version: {version!r}")
+
+    start, end, extra = match.groups()
+    extra = extra or ""
+
+    # Validate that we have a reasonable version format
+    # Reject versions with ~ that aren't qcom/ppa related
+    if "~" in version and not re.search(r"(qcom|~ppa)", version):
+        raise ValueError(f"unable to parse Debian version: {version!r}")
+    
+    # Reject versions that don't look like valid Debian versions
+    # Must have at least one digit or be in a recognized format
+    if not re.search(r"\d", version) or (not re.search(r"[-.]", version) and not re.search(r"qcom|build", version)):
+        raise ValueError(f"unable to parse Debian version: {version!r}")
+
+    if not re.search(r"(qcom|~ppa)(\d+\.)*$", start):
+        build_match = re.match(r"(.*?)(qcom)?(\.?build)", start)
+        if build_match:
+            start = build_match.group(1)
+            end = build_match.group(2) or ""
+
+        if end.startswith("qcom"):
+            native_match = _NATIVE_QCOM_RE.match(start)
+            if not native_match:
+                raise ValueError(
+                    f"native qcom version is missing the numeric part before "
+                    f"'qcom': {version!r}"
+                )
+            if "-" in version:
+                raise ValueError(
+                    "version suffix indicates native qcom package, but the "
+                    "included '-' suggests the contrary"
+                )
+            version_head, version_tail = native_match.groups()
+            start = f"{version_head}{int(version_tail) + 1}"
+        else:
+            end = f"{end}qcom1"
+    else:
+        if end.isdigit():
+            end = str(int(end) + 1)
+        else:
+            raise ValueError(f"unable to increment non-numeric version tail: {version!r}")
+
+    return f"{start}{end}{extra}"
+
+if __name__ == '__main__':
+    print(increment_qcom_version(sys.argv[1]))

--- a/lib/next_qcom_version_test.py
+++ b/lib/next_qcom_version_test.py
@@ -1,0 +1,47 @@
+"""pytest coverage for debchange-style qcom version increments."""
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+import pytest
+
+from next_qcom_version import increment_qcom_version
+
+# Written by QGenie
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.2-3", "1.2-3qcom1"),
+        ("2:1.2-3", "2:1.2-3qcom1"),
+        ("1.2", "1.2qcom1"),
+        ("1.2qcom1", "1.2qcom2"),
+        ("1.2-3qcom1", "1.2-3qcom2"),
+        ("1.2-3qcom9", "1.2-3qcom10"),
+        ("1.2-3qcom1~", "1.2-3qcom2~"),
+        ("1.2-3qcom1+", "1.2-3qcom2+"),
+        ("1.2-3~ppa1", "1.2-4~ppa1"),
+        ("1.2-3~ppa1.1", "1.2-4~ppa1.1"),
+        ("1.2build1", "1.2qcom1"),
+        ("1.2qcombuild1", "1.3qcom"),
+        ("1.2qcom", "1.3qcom"),
+        ("1.0.7qcom10~bpo1", "1.0.7qcom10~bpo2"),
+    ],
+)
+def test_increment_qcom_version(version: str, expected: str) -> None:
+    """Increment versions the same way dch -i does for Ubuntu, but with qcom."""
+    assert increment_qcom_version(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1.2-3qcom",
+        "1.2~rc1",
+        "invalid",
+    ],
+)
+def test_increment_qcom_version_rejects_invalid_inputs(version: str) -> None:
+    """Reject versions outside the supported debchange-derived cases."""
+    with pytest.raises(ValueError):
+        increment_qcom_version(version)

--- a/lib/poll_workflow.py
+++ b/lib/poll_workflow.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python3
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Written by QGenie / claude-4-6-sonnet
+
+"""
+Poll a debusine workflow (work request) until it reaches a terminal state.
+
+Usage
+-----
+Extract the work request ID from ``debusine workflow start --yaml`` and pass
+it to this script::
+
+    # PowerShell
+    $id = (debusine workflow start --yaml --data params.yaml my-template |
+           python -c "import sys,yaml; print(yaml.safe_load(sys.stdin)['id'])")
+    python scripts/poll_workflow.py $id
+
+    # Bash
+    id=$(debusine workflow start --yaml --data params.yaml my-template |
+         python -c "import sys,yaml; print(yaml.safe_load(sys.stdin)['id'])")
+    python scripts/poll_workflow.py "$id"
+
+Exit codes
+----------
+0  Workflow completed with result ``success``.
+1  Workflow completed with result ``failure``, ``error``, or ``skipped``.
+2  Timeout reached before the workflow completed.
+3  Configuration or connection error.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from collections.abc import Callable
+
+import tenacity
+import yaml
+
+from debusine.client.config import ConfigHandler
+from debusine.client.debusine import Debusine
+from debusine.client.exceptions import (
+    ClientConnectionError,
+    NotFoundError,
+    UnexpectedResponseError,
+)
+from debusine.client.models import WorkRequestResponse
+
+# Results that indicate the work request has finished.
+_TERMINAL_RESULTS = {"success", "failure", "error", "skipped"}
+
+# Statuses that mean the work request is still actively progressing and should
+# continue to be polled if no terminal result has been recorded yet.
+_ACTIVE_STATUSES = {"pending", "running"}
+
+# Default adaptive polling parameters (seconds).
+_DEFAULT_WAIT_START = 5
+_DEFAULT_WAIT_INCREMENT = 5
+_DEFAULT_WAIT_MAX = 60
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="poll_workflow.py",
+        description=(
+            "Poll a debusine workflow (work request) until it completes."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "work_request_id",
+        type=int,
+        help=(
+            "Work request ID to poll. "
+            "Obtain it from the 'id' field of 'debusine workflow start --yaml'."
+        ),
+    )
+    parser.add_argument(
+        "--server",
+        default=None,
+        help=(
+            "Debusine server to use, either by section name or as FQDN/scope. "
+            "Uses the configuration file default if not specified."
+        ),
+    )
+    parser.add_argument(
+        "--config-file",
+        default=ConfigHandler.DEFAULT_CONFIG_FILE_PATH,
+        help="Path to the debusine client configuration file.",
+    )
+    parser.add_argument(
+        "--max-interval",
+        type=float,
+        default=_DEFAULT_WAIT_MAX,
+        metavar="SECONDS",
+        help=(
+            "Maximum polling interval in seconds. "
+            "The script starts polling every %(default)s s and increases the "
+            "interval by %(default)s s each attempt up to this cap."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Maximum total time to wait in seconds before giving up. "
+            "If not specified, poll indefinitely."
+        ),
+    )
+    parser.add_argument(
+        "--yaml",
+        action="store_true",
+        help="Print the final WorkRequestResponse as YAML on stdout.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress progress messages (errors are still printed).",
+    )
+    return parser
+
+
+def _setup_logging(quiet: bool) -> logging.Logger:
+    logger = logging.getLogger("poll_workflow")
+    logger.setLevel(logging.WARNING if quiet else logging.INFO)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    return logger
+
+
+def _build_debusine_client(args: argparse.Namespace, logger: logging.Logger) -> Debusine:
+    """Load configuration and return an authenticated Debusine client."""
+    server_name: str | None = os.environ.get("DEBUSINE_SERVER_NAME")
+    if args.server is not None:
+        server_name = args.server
+
+    try:
+        config = ConfigHandler(
+            server_name=server_name,
+            config_file_path=args.config_file,
+        )
+        server_info = config.server_configuration()
+    except SystemExit:
+        # ConfigHandler calls sys.exit(3) on bad config; re-raise as-is.
+        raise
+    except ValueError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        raise SystemExit(3) from exc
+
+    return Debusine(
+        base_api_url=server_info.api_url,
+        api_token=server_info.api_token,
+        scope=server_info.scope,
+        logger=logger,
+    )
+
+
+def _make_before_sleep_log(
+    work_request_id: int,
+    logger: logging.Logger,
+) -> "Callable[[tenacity.RetryCallState], None]":
+    """Return a tenacity before_sleep hook that logs the current status."""
+
+    def _before_sleep(retry_state: tenacity.RetryCallState) -> None:
+        if retry_state.outcome is None:
+            return
+        exc = retry_state.outcome.exception()
+        if exc is not None:
+            logger.info(
+                "Work request %d: connection error (%s). Retrying in %.0f s …",
+                work_request_id,
+                exc,
+                retry_state.next_action.sleep,  # type: ignore[union-attr]
+            )
+            return
+        wr: WorkRequestResponse = retry_state.outcome.result()
+        elapsed = retry_state.outcome_timestamp - retry_state.start_time
+        logger.info(
+            "Work request %d: status=%s result=%r  (elapsed %.0f s, "
+            "next poll in %.0f s)",
+            work_request_id,
+            wr.status,
+            wr.result or "(pending)",
+            elapsed,
+            retry_state.next_action.sleep,  # type: ignore[union-attr]
+        )
+
+    return _before_sleep
+
+
+def _should_continue_polling(wr: WorkRequestResponse) -> bool:
+    """Return True while the work request is still in a non-terminal state."""
+    if wr.result in _TERMINAL_RESULTS:
+        return False
+    return wr.status in _ACTIVE_STATUSES
+
+
+def poll_until_complete(
+    client: Debusine,
+    work_request_id: int,
+    *,
+    max_interval: float,
+    timeout: float | None,
+    logger: logging.Logger,
+) -> WorkRequestResponse:
+    """
+    Poll ``work_request_id`` until it reaches a terminal state.
+
+    Uses tenacity to:
+    * Retry on transient connection/HTTP errors (exponential backoff, up to
+      ~30 s between attempts).
+    * Keep polling while the result is still empty, with an incrementing wait
+      that starts at ``_DEFAULT_WAIT_START`` s and grows by
+      ``_DEFAULT_WAIT_INCREMENT`` s each attempt up to ``max_interval`` s.
+
+    :param client: authenticated Debusine client.
+    :param work_request_id: ID of the work request to poll.
+    :param max_interval: cap on the polling interval (seconds).
+    :param timeout: maximum total elapsed time before giving up (seconds),
+        or ``None`` to poll indefinitely.
+    :param logger: logger for progress messages.
+    :returns: the final :class:`WorkRequestResponse`.
+    :raises tenacity.RetryError: if the timeout is reached.
+    :raises SystemExit(3): on unrecoverable connection errors.
+    """
+    # Inner retry: handle transient network errors when fetching the status.
+    # Uses exponential backoff capped at 30 s, up to ~5 minutes total.
+    _fetch_retry = tenacity.retry(
+        retry=tenacity.retry_if_exception_type(
+            (ClientConnectionError, UnexpectedResponseError)
+        ),
+        wait=tenacity.wait_exponential(multiplier=1, min=2, max=30),
+        stop=tenacity.stop_after_delay(300),
+        reraise=True,
+    )
+
+    @_fetch_retry
+    def _fetch(wr_id: int) -> WorkRequestResponse:
+        return client.work_request_get(wr_id)
+
+    # Outer retry: keep polling while the work request is still active and no
+    # terminal result has been recorded yet. If the server reports a
+    # non-active/terminal status without a success result (for example an error
+    # state), stop polling and let the caller exit non-zero.
+    # The wait increments from _DEFAULT_WAIT_START up to max_interval.
+    stop_condition: tenacity.stop.stop_base
+    if timeout is not None:
+        stop_condition = tenacity.stop_after_delay(timeout)
+    else:
+        stop_condition = tenacity.stop_never
+
+    before_sleep = _make_before_sleep_log(work_request_id, logger)
+
+    poll_retry = tenacity.retry(
+        retry=tenacity.retry_if_result(_should_continue_polling),
+        wait=tenacity.wait_incrementing(
+            start=_DEFAULT_WAIT_START,
+            increment=_DEFAULT_WAIT_INCREMENT,
+            max=max_interval,
+        ),
+        stop=stop_condition,
+        before_sleep=before_sleep,
+        # Do not wrap the result in RetryError on success; re-raise on stop.
+        reraise=False,
+    )
+
+    @poll_retry
+    def _poll() -> WorkRequestResponse:
+        return _fetch(work_request_id)
+
+    return _poll()
+
+
+def main() -> None:
+    """Entry point."""
+    parser = _build_argument_parser()
+    args = parser.parse_args()
+
+    logger = _setup_logging(args.quiet)
+
+    client = _build_debusine_client(args, logger)
+
+    logger.info(
+        "Polling work request %d (max_interval=%.0f s%s) …",
+        args.work_request_id,
+        args.max_interval,
+        f", timeout={args.timeout:.0f} s" if args.timeout else "",
+    )
+
+    try:
+        final_wr = poll_until_complete(
+            client,
+            args.work_request_id,
+            max_interval=args.max_interval,
+            timeout=args.timeout,
+            logger=logger,
+        )
+    except tenacity.RetryError:
+        print(
+            f"Timeout: work request {args.work_request_id} did not complete "
+            f"within {args.timeout:.0f} s.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    except NotFoundError:
+        print(
+            f"Error: work request {args.work_request_id} not found.",
+            file=sys.stderr,
+        )
+        raise SystemExit(3)
+    except (ClientConnectionError, UnexpectedResponseError) as exc:
+        print(f"Connection error: {exc}", file=sys.stderr)
+        raise SystemExit(3)
+
+    logger.info(
+        "Work request %d finished: status=%s result=%s",
+        args.work_request_id,
+        final_wr.status,
+        final_wr.result,
+    )
+
+    if args.yaml:
+        output = yaml.safe_dump(
+            final_wr.model_dump(mode="json"), sort_keys=False
+        )
+        print(output, end="")
+
+    if final_wr.result == "success":
+        raise SystemExit(0)
+    else:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/prepare-debusine
+++ b/lib/prepare-debusine
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Prepare the container to run the Debusine client
+
+# Run on the host
+
+# Dependencies:
+#   incus (configured)
+
+# Inputs:
+#   None
+
+# Outputs:
+#   `debusine` incus container (without Debusine configured)
+
+echo "::group::Prepare debusine container"
+sudo incus launch images:debian/trixie debusine
+sudo incus exec debusine mkdir debusine-action
+sudo incus file push -r debusine-action/lib debusine/root/debusine-action/
+sudo incus exec debusine sh - <<END2
+set -ex
+cat > /etc/apt/sources.list.d/trixie-backports.sources <<END
+Types: deb 
+URIs: http://deb.debian.org/debian 
+Suites: trixie-backports 
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+END
+apt-get --update install --no-install-recommends -y curl dctrl-tools debusine-client/trixie-backports dpkg-dev git python3-debusine/trixie-backports python3-tenacity python3-yaml yq
+END2
+echo "::endgroup::"

--- a/lib/prepare-incus
+++ b/lib/prepare-incus
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Prepare environment to run Incus
+
+# Run on the host
+
+# Dependencies:
+#   None
+
+# Inputs:
+#   None
+
+# Outputs:
+#   None
+
+echo ""::group::Prepare Incus""
+# The default Docker installation steps on iptables and clobbers Incus
+# networking in the process, so remove it and reset iptables
+sudo dpkg -P docker-ce docker-ce-cli
+sudo iptables -t nat -F
+sudo iptables -F
+sudo iptables -P FORWARD ACCEPT
+
+sudo apt-get --update install incus
+sudo systemctl enable --now incus.socket
+sudo incus admin init --auto
+echo "::endgroup::"

--- a/lib/prepare-release
+++ b/lib/prepare-release
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Locally add a commit and tag that adjusts d/changelog for release by changing
+# the distribution from UNRELEASED to the target suite. Save the commit and tag
+# in a git bundle in ../release.bundle so that if tests pass, this commit and
+# tag can be pushed officially later.
+
+# Dependencies:
+#   dpkg-parsechangelog, dch, gbp, git
+
+# Inputs:
+#   $SUITE
+#   Checked out source tree in $PWD/srcpkg
+
+# Outputs:
+#   release.bundle: contains release tag and associated commit
+#   Repository will be checked out at the release tag
+
+tmpdir=$(mktemp -d)
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT
+
+cd srcpkg
+
+# Must be UNRELEASED
+if [ "$(dpkg-parsechangelog -SDistribution)" != "UNRELEASED" ]; then
+    echo "Cannot release: d/changelog does not report UNRELEASED" >&2
+    exit 1
+fi
+
+# Drop any ~ suffix
+original_version=$(dpkg-parsechangelog -SVersion)
+final_release_version=${original_version%\~}
+dch -v "$final_release_version" ''
+
+# Release
+if [ "$SUITE" = "sid" ]; then
+    SUITE=unstable
+fi
+dch -r -D "$SUITE" --force-distribution ''
+
+export GIT_AUTHOR_NAME="Release Bot"
+export GIT_AUTHOR_EMAIL="noreply@example.com"
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+git commit -m"d/changelog: release $final_release_version" debian/changelog
+
+gbp tag --ignore-branch --posttag='echo $GBP_TAG > '"$tmpdir/release-tag"
+git bundle create ../release.bundle "HEAD^..refs/tags/$(cat "$tmpdir/release-tag")"

--- a/lib/prepare-test
+++ b/lib/prepare-test
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Prepare a test environment for a build that is ready to test in Debusine
+
+# In this example, we use a container for testing, so we create the container
+# and configure it with apt. The script lib/generate-apt-config generates the apt
+# configuration for us that points into Debusine. Then we copy that
+# configuration into the container.
+
+# In a real implementation, one would still run lib/generate-apt-config, and then
+# how to set up the system under test accordingly.
+
+# See the comments in lib/generate-apt-config to understand its inputs, outputs
+# and dependencies.
+
+# Run on the host
+
+# Dependencies:
+#   incus (configured)
+#   Dependencies of lib/generate-apt-config
+
+# Inputs:
+#   $SUITE
+#   Inputs of lib/generate-apt-config
+
+# Outputs:
+#   None
+
+echo "::group::Prepare test container"
+debusine-action/lib/generate-apt-config
+sudo incus launch "images:debian/$SUITE" test
+sudo incus exec test -- apt-get install --update --no-install-recommends -y ca-certificates
+sudo incus file push debusine-ci.sources test/etc/apt/sources.list.d/
+sudo incus file push debusine-ci-auth.conf test/etc/apt/auth.conf.d/
+sudo incus exec test apt-get update
+echo "::endgroup::"

--- a/lib/push-release
+++ b/lib/push-release
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Import the commit and tag saved previously by lib/prepare-release. Add a
+# further commit to "open" development of the next release by adding a new
+# UNRELEASED entry to d/changelog. Then push the tag and these two commits back
+# to the origin repository.
+
+# Dependencies:
+#   git dpkg-parsechangelog dch
+
+# Inputs:
+#   $RELEASE_TAG
+#   Checked out branch in $PWD/srcpkg/ directory (without release commit/tag)
+#   release.bundle (containing release commit and tag)
+
+# Outputs:
+#   `git push origin`
+
+cd srcpkg
+# Must not be UNRELEASED
+release_ref=$(git bundle list-heads ../release.bundle|awk '{print $2}')
+git fetch ../release.bundle "${release_ref}:${release_ref}"
+git merge --ff "$release_ref"
+if [ "$(dpkg-parsechangelog -SDistribution)" = "UNRELEASED" ]; then
+    echo "Cannot release: d/changelog reports UNRELEASED" >&2
+    exit 1
+fi
+
+previous_version=$(dpkg-parsechangelog -SVersion)
+next_version=$(../debusine-action/lib/next_qcom_version "$previous_version")
+case "$next_version" in
+    *~) next_dev_version="$next_version" ;;
+    *) next_dev_version="${next_version}~" ;;
+esac
+dch -b -v "$next_dev_version" 'Unreleased changes'
+export GIT_AUTHOR_NAME="Release Bot"
+export GIT_AUTHOR_EMAIL="noreply@example.com"
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+git commit -m"d/changelog: open $next_version" debian/changelog
+git push origin "$release_ref" "$(git symbolic-ref HEAD)"

--- a/lib/release
+++ b/lib/release
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eux
+set -o pipefail
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Release a Debusine build from a ci child workspace into the Debusine prod
+# workspace
+
+# Run inside the container created with `lib/prepare-debusine`
+
+# Dependencies:
+#   `debusine` incus container (Debusine will be configured)
+
+# Inputs:
+#   DEBUSINE_HOST
+#   DEBUSINE_SCOPE
+#   DEBUSINE_TOKEN
+#   DEBUSINE_CI_WORKSPACE
+#   SRCPKG_NAME
+#   SRCPKG_VERSION
+#   SUITE
+
+# Outputs:
+#   None
+
+echo "::group::Release to Debusine prod"
+
+mkdir -p ~/.config/debusine/client
+( umask 077; cat > ~/.config/debusine/client/config.ini <<EOF
+[General]
+default-server = default
+
+[server:default]
+api-url = https://${DEBUSINE_HOST}/api
+scope = ${DEBUSINE_SCOPE}
+token = ${DEBUSINE_TOKEN}
+default-workspace = prod
+EOF
+)
+
+suite_id=$(
+  debusine collection list -w "$DEBUSINE_CI_WORKSPACE" --yaml |
+  yq -r --arg suite "$SUITE" '
+    map(select(.category == "debian:suite" and .name == $suite)) as $m
+    | if ($m | length) == 1
+      then $m[0].id
+      else error("expected exactly one match")
+      end
+  '
+)
+workflow_id=$(debusine workflow start -w prod --yaml package-publish <<END|yq -r .id
+source_artifact: ${suite_id}@collections/${SRCPKG_NAME}_${SRCPKG_VERSION}
+binary_artifacts:
+  category: debian:binary-package
+  collection: ${suite_id}@collections
+target_suite: ${SUITE}@debian:suite
+END
+)
+debusine-action/lib/poll_workflow.py "$workflow_id"
+
+echo "::endgroup::"


### PR DESCRIPTION
Add a parallel implementation that implements our MVP Debusine CI. This diverges from the clean abstraction provided by the work so far, but meets our MVP goal. We will need to converge the two implementations later.

Note: I cannot actually test this until I have a caller workflow ready with a suitable Debusine instance and access token.