### PR TITLE
Correctly prefix 'qcom/' on Debusine release tags

### DIFF
--- a/lib/prepare-release
+++ b/lib/prepare-release
@@ -49,5 +49,5 @@ export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 git commit -m"d/changelog: release $final_release_version" debian/changelog
 
-gbp tag --ignore-branch --posttag='echo $GBP_TAG > '"$tmpdir/release-tag"
+gbp tag --ignore-branch --debian-tag='qcom/debian/%(version)s' --posttag='echo $GBP_TAG > '"$tmpdir/release-tag"
 git bundle create ../release.bundle "HEAD^..refs/tags/$(cat "$tmpdir/release-tag")"


### PR DESCRIPTION
Only official releases to Debian should have bare `debian/<version>` tag names. Following dep14, we should use a `qcom/` prefix on our overlay release tag names.