### PR TITLE
Fixes for the initial Debusine/QLI CI MVP build flow

### DIFF
--- a/lib/build
+++ b/lib/build
@@ -29,7 +29,7 @@ set -o pipefail
 echo "::group::Build in Debusine"
 
 child_ci_suffix=gh-${GITHUB_REPOSITORY_ID}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${JOB_INDEX}
-workspace="ci-${child_ci_suffix}"
+workspace="qli-ci-${child_ci_suffix}"
 
 mkdir -p ~/.config/debusine/client
 ( umask 077; cat > ~/.config/debusine/client/config.ini <<EOF
@@ -44,7 +44,7 @@ default-workspace = $workspace
 EOF
 )
 
-workflow_id=$(echo "suffix: $child_ci_suffix"|debusine workflow start -w ci --yaml create-child-workspace|yq -r .id)
+workflow_id=$(echo "suffix: $child_ci_suffix"|debusine workflow start -w qli-ci --yaml create-child-workspace|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
 debusine archive suite create --architecture all --architecture amd64 --architecture arm64 ${SUITE}
 debusine workflow-template create debian_pipeline debian-pipeline <<END

--- a/lib/build
+++ b/lib/build
@@ -44,7 +44,9 @@ default-workspace = $workspace
 EOF
 )
 
-workflow_id=$(echo "suffix: $child_ci_suffix"|debusine workflow start -w qli-ci --yaml create-child-workspace|yq -r .id)
+workflow_start_output=$(echo "suffix: $child_ci_suffix"|debusine workflow start -w qli-ci --yaml create-child-workspace)
+echo "Workflow start output: $workflow_start_output" >&2
+workflow_id=$(echo "$workflow_start_output"|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
 debusine archive suite create --architecture all --architecture amd64 --architecture arm64 ${SUITE}
 debusine workflow-template create debian_pipeline debian-pipeline <<END
@@ -62,8 +64,11 @@ static_parameters:
 runtime_parameters:
   source_artifact: any
 END
-artifact_id=$(debusine artifact import-debian --yaml *.dsc|yq -r .artifact_id)
-workflow_id=$(echo "source_artifact: ${artifact_id}@artifacts"|debusine workflow start --yaml debian-pipeline|yq -r .id)
+artifact_import_output=$(debusine artifact import-debian --yaml *.dsc)
+echo "Artifact import output: $artifact_import_output" >&2
+artifact_id=$(echo "$artifact_import_output"|yq -r .artifact_id)
+workflow_start_output=$(echo "source_artifact: ${artifact_id}@artifacts"|debusine workflow start --yaml debian-pipeline)
+workflow_id=$(echo "$workflow_start_output"|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
 
 echo "workspace=$workspace" > output

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
+set -o pipefail
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -40,13 +41,32 @@ set -ex
 # 2. Install build dependencies before building the source package
 
 echo "::group::Prepare source package"
+if [ -f "srcpkg/debian/source/format" -a "$(cat srcpkg/debian/source/format)" = "3.0 (quilt)" ]; then
+    # Opportunistically fetch the upstream refs that gbp buildpackage
+    # may use to reconstruct the orig tarball. If these refs aren't available
+    # from our packaging branch, continue anyway to give gbp the opportunity to
+    # use whatever heuristics it wishes; if it is not successful, it is up to
+    # gbp to fail at that stage, not here.
+    cd srcpkg
+    # --depth=1 seems to break gbp's internal pristine-tar extraction, so not
+    # using shallow here for now
+    git fetch origin --no-tags refs/heads/pristine-tar:refs/heads/pristine-tar || true
+    # sed for input sanitization
+    upstream_version=$(dpkg-parsechangelog -SVersion|sed 's/[^A-Za-z0-9.+~:-]//g'|cut -d- -f1)
+    # Use perl for version to tag transformation directly from dep14
+    upstream_tag_ref=refs/tags/upstream/$(echo "$upstream_version"|perl -pe 'y/:~/%_/; s/\.(?=\.|$|lock$)/.#/g')
+    git fetch --depth=1 origin --no-tags "${upstream_tag_ref}:${upstream_tag_ref}"
+    cd ..
+fi
+
 sudo incus launch "images:debian/$SUITE" srcbuild
-sudo incus file push -r srcpkg srcbuild/root/
+tar c srcpkg|sudo incus exec srcbuild -- tar x
+sudo incus exec srcbuild -- chown -R root:root srcpkg
 sudo incus exec srcbuild -- sh - <<END
 set -ex
-apt-get install --update --no-install-recommends -y dpkg-dev
+apt-get install --update --no-install-recommends -y dpkg-dev git-buildpackage pristine-tar
 cd srcpkg
-dpkg-buildpackage -S -d -nc
+gbp buildpackage -S -sa -d -nc --git-builder=dpkg-buildpackage --source-option=--extend-diff-ignore=^\.github -us -uc
 END
 changes_file=$(sudo incus exec srcbuild -- sh -c 'echo *.changes')
 sudo incus file pull "srcbuild/root/$changes_file" .

--- a/lib/release
+++ b/lib/release
@@ -5,7 +5,7 @@ set -o pipefail
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Release a Debusine build from a ci child workspace into the Debusine prod
+# Release a Debusine build from a ci child workspace into the Debusine qli
 # workspace
 
 # Run inside the container created with `lib/prepare-debusine`
@@ -25,7 +25,7 @@ set -o pipefail
 # Outputs:
 #   None
 
-echo "::group::Release to Debusine prod"
+echo "::group::Release to Debusine qli"
 
 mkdir -p ~/.config/debusine/client
 ( umask 077; cat > ~/.config/debusine/client/config.ini <<EOF
@@ -36,7 +36,7 @@ default-server = default
 api-url = https://${DEBUSINE_HOST}/api
 scope = ${DEBUSINE_SCOPE}
 token = ${DEBUSINE_TOKEN}
-default-workspace = prod
+default-workspace = qli
 EOF
 )
 
@@ -50,7 +50,7 @@ suite_id=$(
       end
   '
 )
-workflow_id=$(debusine workflow start -w prod --yaml package-publish <<END|yq -r .id
+workflow_id=$(debusine workflow start -w qli --yaml package-publish <<END|yq -r .id
 source_artifact: ${suite_id}@collections/${SRCPKG_NAME}_${SRCPKG_VERSION}
 binary_artifacts:
   category: debian:binary-package


### PR DESCRIPTION
* Orig tarball generation (in my sandbox, I was using a non-native package so hadn't considered orig tarball handling).
* Rename of workspaces to their final names.
* Better debugging output in case of Debusine-side failures

