### PR TITLE
Ignore branch name for `gbp buildpackage`

### DIFF
--- a/lib/build
+++ b/lib/build
@@ -68,6 +68,7 @@ artifact_import_output=$(debusine artifact import-debian --yaml *.dsc)
 echo "Artifact import output: $artifact_import_output" >&2
 artifact_id=$(echo "$artifact_import_output"|yq -r .artifact_id)
 workflow_start_output=$(echo "source_artifact: ${artifact_id}@artifacts"|debusine workflow start --yaml debian-pipeline)
+echo "Workflow start output: $workflow_start_output" >&2
 workflow_id=$(echo "$workflow_start_output"|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
 

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -66,7 +66,7 @@ sudo incus exec srcbuild -- sh - <<END
 set -ex
 apt-get install --update --no-install-recommends -y dpkg-dev git-buildpackage pristine-tar
 cd srcpkg
-gbp buildpackage -S -sa -d -nc --git-builder=dpkg-buildpackage --source-option=--extend-diff-ignore=^\.github -us -uc
+gbp buildpackage -S -sa -d -nc --git-builder=dpkg-buildpackage --git-ignore-branch --source-option=--extend-diff-ignore=^\.github -us -uc
 END
 changes_file=$(sudo incus exec srcbuild -- sh -c 'echo *.changes')
 sudo incus file pull "srcbuild/root/$changes_file" .

--- a/lib/release
+++ b/lib/release
@@ -50,7 +50,7 @@ suite_id=$(
       end
   '
 )
-workflow_id=$(debusine workflow start -w qli --yaml package-publish <<END|yq -r .id
+workflow_start_output=$(debusine workflow start -w qli --yaml package-publish <<END
 source_artifact: ${suite_id}@collections/${SRCPKG_NAME}_${SRCPKG_VERSION}
 binary_artifacts:
   category: debian:binary-package
@@ -58,6 +58,8 @@ binary_artifacts:
 target_suite: ${SUITE}@debian:suite
 END
 )
+echo "Workflow start output: $workflow_start_output" >&2
+workflow_id=$(echo "$workflow_start_output"|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
 
 echo "::endgroup::"


### PR DESCRIPTION
Ignore branch name for `gbp buildpackage`

`gbp buildpackage` will fail if the branch name in use does not match its expectation of the Debian packaging branch to use, as often configured in debian/gbp.conf. For daily and release flows, this is nice, since it forces debian/gbp.conf to have the correct definition.  However, in the PR flow, we're usually on a detached HEAD since GitHub constructs a "what this PR would look like if merged" ref that does not exist as a branch. In this case, we need `gbp buildpackage` to ignore the branch configuration with --git-ignore-branch.

While having it fail in the daily and release flows would be nice, I think 1) it really fails too late and in a way that would be fairly confusing for average engineers to discern; but more importantly 2) it would be too late to fail at that stage anyway; it should have failed at PR stage, but we have to use --git-ignore-branch for that since the PR branch name isn't the final name anyway.

To have this linted well, we could have a direct lint check conducted as a separate check that would be independent of Debusine, but that is out of scope. So I think it's correct to universally use --git-ignore-branch for the Debusine CI flow, and leave a lint for the branch as a separate unrelated wishlist item.

I've also bundled a debugging improvement into this PR.