### PR TITLE
Add packaging repository workflows

### DIFF
--- a/packaging-workflows/README.debusine.md
+++ b/packaging-workflows/README.debusine.md
@@ -1,0 +1,8 @@
+The `debusine-*.yml` files form a set of workflows that have been imported from
+the
+https://github.com/qualcomm-linux/debusine-action/tree/main/packaging-workflows
+reference location to enable Debusine CI. They must not be changed except to
+copy updates from the reference location. They will be updated as the reference
+location is updated. See
+[README.md](https://github.com/qualcomm-linux/debusine-action/blob/main/packaging-workflows/README.md)
+for details.

--- a/packaging-workflows/README.md
+++ b/packaging-workflows/README.md
@@ -1,0 +1,11 @@
+This is a set of four workflows that should be imported into each pkg-*
+repository to enable Debusine CI. They must be placed in the default branch,
+and debusine-pr-hook.yml and debusine-release.yml must also be copied to each
+enabled packaging (`qcom/debian/*)` branch. README.debusine.md should also be
+copied into each branch touched to help future maintainers.
+
+When these files are updated, they must also updated in every "managed" pkg-*
+repository. Currently this process is manual. We
+[agreed](https://github.com/qualcomm-linux/debusine-action/pull/15) that once
+landed into this repository through a peer-reviewed PR, no further PRs are
+required to update the corresponding workflow files in the pkg-* repositories.

--- a/packaging-workflows/debusine-daily.yml
+++ b/packaging-workflows/debusine-daily.yml
@@ -1,0 +1,63 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# SEE README.debusine.md BEFORE CHANGING THIS FILE
+
+name: Debusine Daily
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  # For scheduled runs, determine which target branches exist
+  check-branches:
+    name: Check branches
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: set-matrix
+        name: Set matrix
+        run: |
+          # Define candidate branches (duplicated from workflow_dispatch options in debusine.yml)
+          candidates='["qcom/debian/latest", "qcom/debian/trixie"]'
+
+          # Filter to branches that exist
+          existing=()
+          for branch in $(echo "$candidates" | jq -r '.[]'); do
+            if git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+              existing+=("\"$branch\"")
+            fi
+          done
+
+          # Create JSON array
+          matrix="[$(IFS=,; echo "${existing[*]}")]"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Existing branches: $matrix"
+
+  # For scheduled runs, call the workflow once per existing branch
+  debusine-scheduled:
+    name: Debusine (${{ matrix.target_branch }})
+    needs: check-branches
+    strategy:
+      fail-fast: false
+      matrix:
+        target_branch: ${{ fromJson(needs.check-branches.outputs.matrix) }}
+    uses: qualcomm-linux/debusine-action/.github/workflows/debusine.yml@main
+    with:
+      target_branch: ${{ matrix.target_branch }}
+      source_ref: refs/heads/${{ matrix.target_branch }}
+      release: false
+      job_index: ${{ strategy.job-index }}
+    permissions:
+      contents: write
+      deployments: write
+    secrets:
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+      DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}

--- a/packaging-workflows/debusine-pr-check.yml
+++ b/packaging-workflows/debusine-pr-check.yml
@@ -1,0 +1,65 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# SEE README.debusine.md BEFORE CHANGING THIS FILE
+
+name: Debusine PR Check
+
+on:
+  workflow_run:
+    workflows: ["Debusine PR Hook"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  deployments: write
+  statuses: write
+
+jobs:
+  debusine:
+    name: Debusine
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: qualcomm-linux/debusine-action/.github/workflows/debusine.yml@main
+    with:
+      source_ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/merge
+      target_branch: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+      release: false
+    secrets:
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+      DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
+
+  set-final-status:
+    name: Set Debusine CI Result
+    runs-on: ubuntu-latest
+    needs: debusine
+    if: always()
+    steps:
+      - name: Set success status
+        if: needs.debusine.result == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              state: 'success',
+              context: 'Debusine CI',
+              description: 'Debusine CI passed'
+            });
+
+      - name: Set failure status
+        if: needs.debusine.result != 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              state: 'failure',
+              context: 'Debusine CI',
+              description: 'Debusine CI failed'
+            });

--- a/packaging-workflows/debusine-pr-hook.yml
+++ b/packaging-workflows/debusine-pr-hook.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# SEE README.debusine.md BEFORE CHANGING THIS FILE
+
+# Note: in addition to the default branch, this workflow file must also be
+# copied into each packaging branch in order to function as intended.
+
+name: Debusine PR Hook
+
+on:
+  pull_request:
+    branches:
+      - 'qcom/debian/**'
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  set-pending-status:
+    name: Create Debusine CI Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set pending status
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'Debusine CI',
+              description: 'Running Debusine CI...'
+            });

--- a/packaging-workflows/debusine-release.yml
+++ b/packaging-workflows/debusine-release.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# SEE README.debusine.md BEFORE CHANGING THIS FILE
+
+# Note: in addition to the default branch, this workflow file must also be
+# copied into each packaging branch in order to function as intended.
+
+name: Debusine Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Run release step
+        type: boolean
+        required: true
+        default: false
+
+jobs:
+  debusine:
+    name: Debusine
+    if: startsWith(github.ref_name, 'qcom/debian/')
+    uses: qualcomm-linux/debusine-action/.github/workflows/debusine.yml@main
+    with:
+      target_branch: ${{ github.ref_name }}
+      release: ${{ inputs.release }}
+    permissions:
+      contents: write
+      deployments: write
+    secrets:
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+      DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}


### PR DESCRIPTION
This is a set of four workflows that should be imported into a pkg-* repository to enable Debusine CI. They must be placed in the default branch, and debusine-pr-hook.yml and debusine-release.yml must also be copied to every packaging branch.

This packaging-workflows/ directory is intended to be maintained as the reference location to deploy and keep updated all pkg-* repository Debusine CI workflow files.

There is technical debt here: the contents of these files could be further reduced to stubs that call another layer of reusable workflow provided by this repository instead. This is deferred for now, with the mitigation that keeping these files in the pkg-* repositories updated will be required anyway, and these reference files and the reusable workflow file are at least being kept together in this same repository.