### PR TITLE
fix: workflows: declare debusine_scope

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   debusine_server:
     description: 'Debusine server URL (optional, defaults to dev.debian.qualcomm.com)'
     required: false
+  debusine_scope:
+    description: 'Debusine API scope (optional, defaults to qualcomm)'
+    required: false
 
 outputs:
   workflow_id:


### PR DESCRIPTION
The input was already used and passed to sub-actions but never
declared, producing "Unexpected input(s) 'debusine_scope'" warnings.
