### PR TITLE
Set name/email correctly in d/changelog and git

### DIFF
--- a/lib/prepare-release
+++ b/lib/prepare-release
@@ -41,10 +41,10 @@ dch -v "$final_release_version" ''
 if [ "$SUITE" = "sid" ]; then
     SUITE=unstable
 fi
-dch -r -D "$SUITE" --force-distribution ''
+DEBFULLNAME="Release Bot" DEBEMAIL="noreply@release-bot.invalid" dch -r -D "$SUITE" --force-distribution ''
 
 export GIT_AUTHOR_NAME="Release Bot"
-export GIT_AUTHOR_EMAIL="noreply@example.com"
+export GIT_AUTHOR_EMAIL="noreply@release-bot.invalid"
 export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 git commit -m"d/changelog: release $final_release_version" debian/changelog

--- a/lib/push-release
+++ b/lib/push-release
@@ -36,9 +36,9 @@ case "$next_version" in
     *~) next_dev_version="$next_version" ;;
     *) next_dev_version="${next_version}~" ;;
 esac
-dch -b -v "$next_dev_version" 'Unreleased changes'
+DEBFULLNAME="Release Bot" DEBEMAIL="noreply@release-bot.invalid" dch -b -v "$next_dev_version" 'Unreleased changes'
 export GIT_AUTHOR_NAME="Release Bot"
-export GIT_AUTHOR_EMAIL="noreply@example.com"
+export GIT_AUTHOR_EMAIL="noreply@release-bot.invalid"
 export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 git commit -m"d/changelog: open $next_version" debian/changelog


### PR DESCRIPTION
The name was appearing empty and the email was based on a GitHub runner hostname, which doesn't make sense externally. Set it to an arbitrary RFC2606-compliant "noreply" address instead. Now that I think about it and considering the purposes listed in the standard, .invalid seems better than example.com. Unify the git commits to match.

We can bikeshed the name and address if you like :-)

This needs testing manually, so I'm leaving it as a Draft for now so it's not forgotten.