### PR TITLE
Handle upstream tags configured differently

### DIFF
--- a/lib/build
+++ b/lib/build
@@ -28,7 +28,7 @@ set -o pipefail
 
 echo "::group::Build in Debusine"
 
-child_ci_suffix=gh-${GITHUB_REPOSITORY_ID}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${JOB_INDEX}
+child_ci_suffix=gh-${GITHUB_REPOSITORY_ID:-0}-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-${JOB_INDEX:-0}
 workspace="qli-ci-${child_ci_suffix}"
 
 mkdir -p ~/.config/debusine/client

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -36,6 +36,8 @@ set -o pipefail
 #         referenced files
 #     $GITHUB_OUTPUT (append): srcpkg_name, srcpkg_version
 
+: ${GITHUB_OUTPUT:=/dev/null}
+
 # A couple of things we might want to implement in the future:
 # 1. Run as a normal user, not root
 # 2. Install build dependencies before building the source package

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -55,9 +55,17 @@ if [ -f "srcpkg/debian/source/format" -a "$(cat srcpkg/debian/source/format)" = 
     git fetch origin --no-tags refs/heads/pristine-tar:refs/heads/pristine-tar || true
     # sed for input sanitization
     upstream_version=$(dpkg-parsechangelog -SVersion|sed 's/[^A-Za-z0-9.+~:-]//g'|cut -d- -f1)
-    # Use perl for version to tag transformation directly from dep14
-    upstream_tag_ref=refs/tags/upstream/$(echo "$upstream_version"|perl -pe 'y/:~/%_/; s/\.(?=\.|$|lock$)/.#/g')
-    git fetch --depth=1 origin --no-tags "${upstream_tag_ref}:${upstream_tag_ref}"
+    # Get the upstream tag pattern from gbp config
+    upstream_tag_pattern=$(gbp config buildpackage.upstream-tag)
+    # Only proceed if the pattern contains %(version)s
+    if echo "$upstream_tag_pattern" | grep -qF '%(version)s'; then
+        # Use perl for version to tag transformation directly from dep14
+        transformed_version=$(echo "$upstream_version"|perl -pe 'y/:~/%_/; s/\.(?=\.|$|lock$)/.#/g')
+        # Substitute %(version)s, sanitize, and prepend refs/tags/
+        upstream_tag_ref=refs/tags/$(echo "$upstream_tag_pattern" | sed "s|%(version)s|$transformed_version|" | sed 's/[^A-Za-z0-9.+/%_#()-]//g')
+        # Validate the ref format before fetching
+        git check-ref-format "$upstream_tag_ref" && git fetch --depth=1 origin --no-tags "${upstream_tag_ref}:${upstream_tag_ref}"
+    fi
     cd ..
 fi
 

--- a/lib/generate-step-summary
+++ b/lib/generate-step-summary
@@ -23,6 +23,8 @@ set -ex
 # Outputs:
 #   $GITHUB_STEP_SUMMARY: summary output for the web UI
 
+: ${GITHUB_STEP_SUMMARY:=/dev/null}
+
 qli_public_key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/qli/signing-keys.asc"|sed -e 's/^$/./;s/^/ /')
 ci_public_key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${DEBUSINE_WORKSPACE}/signing-keys.asc"|sed -e 's/^$/./;s/^/ /')
 


### PR DESCRIPTION
If packaging redefines upstream-tag in debian/gbp.conf, then we should fetch that tag before handing over to `gbp buildpackage`.

Otherwise it cannot reconstruct the orig tarball when the upstream tag pattern is different. This is currently the case with pkg-fastrpc. We haven't finalised a standard for how we want this to work, but in the meantime debian/gbp.conf does set upstream-tag to match what we have, and the generic generate-source-package script should handle it correctly.

Handle this correctly by fetching the setting using `gbp config`.  The resulting tag is sanitized appropriately so that we can avoid trusting the source tree.

I have tested this by running generate-source-package locally (after a minor tweak - see first commit) before the fix, which reproduced the problem from https://github.com/qualcomm-linux/pkg-fastrpc/actions/runs/25250701277/job/74042233242), and then after the fix, where it worked as expected. I've also checked that the fixed version still works with pkg-alsa-ucm-conf locally.

I have not tested 0c158a7 directly although I can see that the pattern works in generate-source-package in my test. I trust it is trivially reviewable enough to not bother with all the arrangements I need to make to test it before landing this PR.