### PR TITLE
Install git-buildpackage dependency

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -132,7 +132,7 @@ jobs:
           fi
 
           echo "::group::Generate source package"
-          sudo apt-get install --update --no-install-recommends -y devscripts dctrl-tools
+          sudo apt-get install --update --no-install-recommends -y devscripts dctrl-tools git-buildpackage
           SUITE="$SUITE" debusine-action/lib/generate-source-package
           dcmd sudo incus file push *.changes debusine/root/
           echo "::endgroup::"

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -26,6 +26,7 @@ set -o pipefail
 #     incus (configured)
 #     devscripts
 #     dctrl-tools
+#     git-buildpackage
 
 # Inputs:
 #     $PWD/srcpkg/: checked out source tree


### PR DESCRIPTION
This is required by generate-source-package now.

Fixes: 3b4ae15