### PR TITLE
Add support for alternate library branch

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -6,6 +6,11 @@ name: Debusine CI
 on:
   workflow_call:
     inputs:
+      workflow_ref:
+        description: where this called workflow should find its own implementation
+        type: string
+        default: main
+        required: false
       target_branch:
         description: Where the packaging will land (or for dailies, has landed)
         type: string
@@ -103,7 +108,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: qualcomm-linux/debusine-action
-          ref: main
+          ref: ${{ inputs.workflow_ref }}
           path: debusine-action
       - id: build
         name: Build
@@ -188,7 +193,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: qualcomm-linux/debusine-action
-          ref: main
+          ref: ${{ inputs.workflow_ref }}
           path: debusine-action
       - name: Download release bundle
         uses: actions/download-artifact@v8


### PR DESCRIPTION
This workflow needs to loads its own internal implementation library. This was hardcoded to the main branch, but that makes it difficult to test changes. Add a `workflow_ref` that still defaults to main but can be overridden by a caller for testing.

Then to test a change, we can push just the change to a different branch, and then a test caller can call both the workflow in an alternative branch and also provide `workflow_ref` that points to the same alternative branch so that it can find itself.

Thanks to Simon for telling me how to do this!

I've tested this by using this new feature:

[With workflow_ref specified](https://github.com/qualcomm-linux/equivs-dummy/actions/runs/25505277126/job/74849114982): the log shows that it did pick up the ref from this branch (commit hash output of actions/checkout).

[Without workflow_ref specified](https://github.com/qualcomm-linux/equivs-dummy/actions/runs/25505006055/job/74848111956): the log shows that it did use this branch for the workflow, but did not check out this branch but got the commit from main instead as expected (commit hash output of actions/checkout).