### PR TITLE
Add caller-controlled orig tarball assembly for externally-prepared source trees

### DIFF
--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -38,11 +38,11 @@ set -o pipefail
 # 2. Install build dependencies before building the source package
 
 echo "::group::Prepare source package"
-if [ -f "srcpkg/debian/source/format" -a "$(cat srcpkg/debian/source/format)" = "3.0 (quilt)" ] && [ ! -f "srcpkg/debian/gbp.conf" ]; then
-    # Non-gbp quilt path: source tree was prepared externally (e.g.
-    # pkg-linux-qcom). There is no gbp.conf, no pristine-tar branch, and no
-    # upstream tag. Build the source package directly using dpkg-buildpackage
-    # -S after creating the orig tarball from the source tree.
+if [ "${DEBUSINE_ASSEMBLE_ORIG:-false}" = "true" ]; then
+    # Caller has requested direct orig tarball assembly: the source tree was
+    # prepared externally and has no upstream tarball available via gbp or
+    # pristine-tar. Create the .orig.tar.gz from the source tree and invoke
+    # dpkg-buildpackage -S directly.
     cd srcpkg
     git config --global --add safe.directory "$(pwd)"
     PKG=$(dpkg-parsechangelog -SSource)

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -16,6 +16,11 @@ set -o pipefail
 # This script is expected to run directly inside a job container that already
 # matches the target suite.
 
+# Note: this script is invoked both by the debusine reusable workflow defined
+# in this repository and by qualcomm-linux/qcom-build-utils. Any interface
+# changes (inputs, outputs, behaviour) must be coordinated across both callers
+# to avoid silent breakage.
+
 # Dependencies:
 #     devscripts
 #     dctrl-tools
@@ -25,6 +30,10 @@ set -o pipefail
 # Inputs:
 #     $PWD/srcpkg/: checked out source tree
 #     $SUITE: target suite to prepare in (eg. 'trixie')
+#     $DEBUSINE_ASSEMBLE_ORIG (optional, default: false): when 'true', create
+#         the .orig.tar.gz directly from the source tree and invoke
+#         dpkg-buildpackage -S, bypassing gbp. Use for source trees assembled
+#         at CI time with no upstream tarball available via gbp or pristine-tar.
 
 # Outputs:
 #     Parent directory: .changes files for source package together with all
@@ -38,15 +47,19 @@ set -o pipefail
 # 2. Install build dependencies before building the source package
 
 echo "::group::Prepare source package"
+cd srcpkg
+git config --global --add safe.directory "$(pwd)"
+cd ..
 if [ "${DEBUSINE_ASSEMBLE_ORIG:-false}" = "true" ]; then
     # Caller has requested direct orig tarball assembly: the source tree was
     # prepared externally and has no upstream tarball available via gbp or
     # pristine-tar. Create the .orig.tar.gz from the source tree and invoke
     # dpkg-buildpackage -S directly.
     cd srcpkg
-    git config --global --add safe.directory "$(pwd)"
-    PKG=$(dpkg-parsechangelog -SSource)
-    VER=$(dpkg-parsechangelog -SVersion)
+    # sed for input sanitization — Debian policy restricts package names to
+    # [a-z0-9][a-z0-9.+-]+ and versions to [A-Za-z0-9.+~:-].
+    PKG=$(dpkg-parsechangelog -SSource|sed 's/[^a-z0-9.+-]//g')
+    VER=$(dpkg-parsechangelog -SVersion|sed 's/[^A-Za-z0-9.+~:-]//g')
     UPSTREAM_VER=$(echo "$VER" | sed 's/-[^-]*$//')
     ORIG_TAR="../${PKG}_${UPSTREAM_VER}.orig.tar.gz"
     echo "Creating orig tarball: ${ORIG_TAR}"
@@ -81,7 +94,6 @@ else
     fi
 
     cd srcpkg
-    git config --global --add safe.directory "$(pwd)"
     gbp buildpackage -S -sa -d -nc --git-builder=dpkg-buildpackage --git-ignore-branch --source-option=--extend-diff-ignore=^\.github -us -uc
     cd ..
 fi

--- a/lib/generate-source-package
+++ b/lib/generate-source-package
@@ -38,36 +38,53 @@ set -o pipefail
 # 2. Install build dependencies before building the source package
 
 echo "::group::Prepare source package"
-if [ -f "srcpkg/debian/source/format" -a "$(cat srcpkg/debian/source/format)" = "3.0 (quilt)" ]; then
-    # Opportunistically fetch the upstream refs that gbp buildpackage
-    # may use to reconstruct the orig tarball. If these refs aren't available
-    # from our packaging branch, continue anyway to give gbp the opportunity to
-    # use whatever heuristics it wishes; if it is not successful, it is up to
-    # gbp to fail at that stage, not here.
+if [ -f "srcpkg/debian/source/format" -a "$(cat srcpkg/debian/source/format)" = "3.0 (quilt)" ] && [ ! -f "srcpkg/debian/gbp.conf" ]; then
+    # Non-gbp quilt path: source tree was prepared externally (e.g.
+    # pkg-linux-qcom). There is no gbp.conf, no pristine-tar branch, and no
+    # upstream tag. Build the source package directly using dpkg-buildpackage
+    # -S after creating the orig tarball from the source tree.
     cd srcpkg
-    # --depth=1 seems to break gbp's internal pristine-tar extraction, so not
-    # using shallow here for now
-    git fetch origin --no-tags refs/heads/pristine-tar:refs/heads/pristine-tar || true
-    # sed for input sanitization
-    upstream_version=$(dpkg-parsechangelog -SVersion|sed 's/[^A-Za-z0-9.+~:-]//g'|cut -d- -f1)
-    # Get the upstream tag pattern from gbp config
-    upstream_tag_pattern=$(gbp config buildpackage.upstream-tag)
-    # Only proceed if the pattern contains %(version)s
-    if echo "$upstream_tag_pattern" | grep -qF '%(version)s'; then
-        # Use perl for version to tag transformation directly from dep14
-        transformed_version=$(echo "$upstream_version"|perl -pe 'y/:~/%_/; s/\.(?=\.|$|lock$)/.#/g')
-        # Substitute %(version)s, sanitize, and prepend refs/tags/
-        upstream_tag_ref=refs/tags/$(echo "$upstream_tag_pattern" | sed "s|%(version)s|$transformed_version|" | sed 's/[^A-Za-z0-9.+/%_#()-]//g')
-        # Validate the ref format before fetching
-        git check-ref-format "$upstream_tag_ref" && git fetch --depth=1 origin --no-tags "${upstream_tag_ref}:${upstream_tag_ref}"
+    git config --global --add safe.directory "$(pwd)"
+    PKG=$(dpkg-parsechangelog -SSource)
+    VER=$(dpkg-parsechangelog -SVersion)
+    UPSTREAM_VER=$(echo "$VER" | sed 's/-[^-]*$//')
+    ORIG_TAR="../${PKG}_${UPSTREAM_VER}.orig.tar.gz"
+    echo "Creating orig tarball: ${ORIG_TAR}"
+    tar czf "$ORIG_TAR" --exclude=./debian --exclude=./.git .
+    dpkg-buildpackage -S -sa -d -nc -us -uc
+    cd ..
+else
+    if [ -f "srcpkg/debian/source/format" -a "$(cat srcpkg/debian/source/format)" = "3.0 (quilt)" ]; then
+        # Opportunistically fetch the upstream refs that gbp buildpackage
+        # may use to reconstruct the orig tarball. If these refs aren't available
+        # from our packaging branch, continue anyway to give gbp the opportunity to
+        # use whatever heuristics it wishes; if it is not successful, it is up to
+        # gbp to fail at that stage, not here.
+        cd srcpkg
+        # --depth=1 seems to break gbp's internal pristine-tar extraction, so not
+        # using shallow here for now
+        git fetch origin --no-tags refs/heads/pristine-tar:refs/heads/pristine-tar || true
+        # sed for input sanitization
+        upstream_version=$(dpkg-parsechangelog -SVersion|sed 's/[^A-Za-z0-9.+~:-]//g'|cut -d- -f1)
+        # Get the upstream tag pattern from gbp config
+        upstream_tag_pattern=$(gbp config buildpackage.upstream-tag)
+        # Only proceed if the pattern contains %(version)s
+        if echo "$upstream_tag_pattern" | grep -qF '%(version)s'; then
+            # Use perl for version to tag transformation directly from dep14
+            transformed_version=$(echo "$upstream_version"|perl -pe 'y/:~/%_/; s/\.(?=\.|$|lock$)/.#/g')
+            # Substitute %(version)s, sanitize, and prepend refs/tags/
+            upstream_tag_ref=refs/tags/$(echo "$upstream_tag_pattern" | sed "s|%(version)s|$transformed_version|" | sed 's/[^A-Za-z0-9.+/%_#()-]//g')
+            # Validate the ref format before fetching
+            git check-ref-format "$upstream_tag_ref" && git fetch --depth=1 origin --no-tags "${upstream_tag_ref}:${upstream_tag_ref}"
+        fi
+        cd ..
     fi
+
+    cd srcpkg
+    git config --global --add safe.directory "$(pwd)"
+    gbp buildpackage -S -sa -d -nc --git-builder=dpkg-buildpackage --git-ignore-branch --source-option=--extend-diff-ignore=^\.github -us -uc
     cd ..
 fi
-
-cd srcpkg
-git config --global --add safe.directory "$(pwd)"
-gbp buildpackage -S -sa -d -nc --git-builder=dpkg-buildpackage --git-ignore-branch --source-option=--extend-diff-ignore=^\.github -us -uc
-cd ..
 
 changes_path=$(printf '%s\n' *.changes)
 if [ "$(printf '%s\n' "$changes_path" | wc -l)" -ne 1 ]; then


### PR DESCRIPTION
## Problem

`generate-source-package` has no mechanism to handle source trees that
were assembled externally and have no upstream tarball available via gbp
or pristine-tar. Attempting to build such a package causes `gbp` to fail
when it cannot locate or reconstruct the orig tarball.

## Solution

Add a `DEBUSINE_ASSEMBLE_ORIG` environment variable (default: false).
When set to `true`, the script:

1. Creates the `.orig.tar.gz` directly from the source tree, excluding
   `debian/` (the packaging overlay) and `.git/` (version-control history)
2. Invokes `dpkg-buildpackage -S` to produce the `.dsc`, `.debian.tar.xz`,
   and `.changes` files

The caller, which has full knowledge of its own packaging structure and
upstream tarball availability, sets this flag explicitly. All existing
gbp-managed paths are unchanged.

## Rationale

Callers such as `pkg-linux-qcom` assemble their source tree at CI time
with no upstream tarball available via gbp or pristine-tar. An explicit
flag makes the contract between caller and script unambiguous and avoids
encoding packaging decisions as heuristics inside this script.

## Testing

Validated against `pkg-linux-qcom` (`3.0 (quilt)`), kernel
`7.1.0-rc2-qcom-next-20260515`, suite `trixie`:

```
linux-image-7.1.0-rc2-qcom-next-20260515-qcom_1.orig.tar.gz
linux-image-7.1.0-rc2-qcom-next-20260515-qcom_1-1.debian.tar.xz
linux-image-7.1.0-rc2-qcom-next-20260515-qcom_1-1.dsc
linux-image-7.1.0-rc2-qcom-next-20260515-qcom_1-1_source.changes
```


The existing gbp-managed path was not exercised by this change and remains
unmodified.