### PR TITLE
chore: unify parent workspace fallback

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -28,7 +28,6 @@ on:
         description: Parent Debusine workspace used to create per-run CI child workspaces
         type: string
         required: false
-        default: qli-ci
       job_index:
         # This is used to generate a unique Debusine child workspace name for
         # each expansion of the matrix

--- a/packaging-workflows/debusine-daily.yml
+++ b/packaging-workflows/debusine-daily.yml
@@ -54,7 +54,7 @@ jobs:
       source_ref: refs/heads/${{ matrix.target_branch }}
       release: false
       debusine-action-ref: main
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'qli-ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
       job_index: ${{ strategy.job-index }}
     permissions:
       contents: write

--- a/packaging-workflows/debusine-pr-check.yml
+++ b/packaging-workflows/debusine-pr-check.yml
@@ -27,7 +27,7 @@ jobs:
       target_branch: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
       release: false
       debusine-action-ref: main
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'qli-ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
     secrets:
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
       DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}

--- a/packaging-workflows/debusine-release.yml
+++ b/packaging-workflows/debusine-release.yml
@@ -27,7 +27,7 @@ jobs:
       source_ref: refs/heads/${{ github.ref_name }}
       release: ${{ inputs.release }}
       debusine-action-ref: main
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'qli-ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
     permissions:
       contents: write
       deployments: write


### PR DESCRIPTION
## Summary
- make `debusine-parent-workspace` optional in reusable workflow input contract (no workflow-level default)
- keep fallback behavior centralized in `lib/build` (`DEBUSINE_PARENT_WORKSPACE:-qli-ci`)
- remove hardcoded fallback literals from packaging workflow callers

## Why
This keeps parent workspace defaulting in one place while preserving optional caller override behavior.