### PR TITLE
ci: fix package permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,8 @@ jobs:
       options: --user root
     permissions:
       pull-requests: read
-      contents: write 
+      contents: write
+      packages: read
     steps:
 
       - name: Checkout repository


### PR DESCRIPTION
Add explicit packages read permission. Despite it being at the top, if you declare it in a job the whole block is replaced, not merged.

Testing to see if it fixes the package fetch