### PR TITLE
ci: add AXIOM_Check gate between build and release

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -234,10 +234,20 @@ jobs:
         run: |
           debusine-action/lib/generate-step-summary
 
+  AXIOM_Check:
+    name: AXIOM_Check
+    if: ${{ inputs.release && vars.AXIOM_ENABLE == 'true' }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: Axiom
+    steps:
+      - name: AXIOM check passed
+        run: echo "AXIOM check passed"
+
   release:
     name: Release
-    if: ${{ inputs.release }}
-    needs: [resolve, source-package, build]
+    if: ${{ always() && inputs.release && needs.build.result == 'success' && needs.AXIOM_Check.result != 'failure' && needs.AXIOM_Check.result != 'cancelled' }}
+    needs: [resolve, source-package, build, AXIOM_Check]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/qualcomm-linux/debusine-pkg-builder:trixie


### PR DESCRIPTION
- Add AXIOM_Check job bound to the AXIOM_CHECK environment, which sits between build and release and is auto-approved by the service account once AXIOM tests pass.
- Make the gate opt-in per caller repo via the AXIOM_ENABLE variable: set to '1' to enforce AXIOM_Check, unset or '0' to skip it and fall back to the existing Production manual review only for the AXIOM disable targets.