### PR TITLE
qli-staging workspace handling

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -59,6 +59,9 @@ jobs:
       suite: ${{ steps.map_suite.outputs.suite }}
       source_ref: ${{ steps.determine_checkout_ref.outputs.source_ref }}
       debusine_action_ref: ${{ inputs.debusine-action-ref }}
+      debusine_target_workspace: ${{ steps.map_suite.outputs.debusine_target_workspace }}
+      package_version_identifier: ${{ steps.map_suite.outputs.package_version_identifier }}
+      environment: ${{ steps.map_suite.outputs.environment }}
     steps:
       - id: map_suite
         name: Map branch to suite
@@ -67,21 +70,37 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target_branch }}
         with:
           script: |
-            const suiteMap = {
-              "qcom/debian/latest": "forky",
-              "qcom/debian/trixie": "trixie",
+            const suffixToSuite = {
+              "debian/latest": "forky",
+              "debian/trixie": "trixie",
             };
 
-            const targetBranch = process.env.TARGET_BRANCH;
-            const suite = suiteMap[targetBranch];
+            const prefixMap = [
+              { prefix: 'qli-staging/', workspace: 'qli-staging', identifier: 'qli+staging', environment: 'Staging'    },
+              { prefix: 'qli/',         workspace: 'qli',          identifier: 'qli',         environment: 'Production' },
+              { prefix: 'qcom/',        workspace: 'qli',          identifier: 'qli',         environment: 'Production' },
+            ];
 
+            const targetBranch = process.env.TARGET_BRANCH;
+            const prefixEntry = prefixMap.find(e => targetBranch.startsWith(e.prefix));
+            if (!prefixEntry) {
+              core.setFailed(`Unknown target branch prefix: ${targetBranch}. Branch must start with one of: ${prefixMap.map(e => e.prefix).join(', ')}`);
+              return;
+            }
+            const { workspace, identifier } = prefixEntry;
+            const branchSuffix = targetBranch.slice(prefixEntry.prefix.length);
+
+            const suite = suffixToSuite[branchSuffix];
             if (!suite) {
-              core.setFailed(`Unknown target branch: ${targetBranch}. Valid branches are: ${Object.keys(suiteMap).join(', ')}`);
+              core.setFailed(`Unknown branch suffix: ${branchSuffix}. Valid suffixes are: ${Object.keys(suffixToSuite).join(', ')}`);
               return;
             }
 
             core.setOutput('suite', suite);
-            core.info(`Mapped branch '${targetBranch}' to suite '${suite}'`);
+            core.setOutput('debusine_target_workspace', workspace);
+            core.setOutput('package_version_identifier', identifier);
+            core.setOutput('environment', prefixEntry.environment);
+            core.info(`Mapped branch '${targetBranch}' to suite '${suite}', workspace '${workspace}', identifier '${identifier}', environment '${prefixEntry.environment}'`);
       - id: determine_checkout_ref
         name: Determine the ref of the packaging to build
         uses: actions/github-script@v9
@@ -136,6 +155,7 @@ jobs:
         if: ${{ inputs.release }}
         env:
           SUITE: ${{ needs.resolve.outputs.suite }}
+          DEBUSINE_TARGET_WORKSPACE: ${{ needs.resolve.outputs.debusine_target_workspace }}
         run: |
           set -ex
           debusine-action/lib/prepare-release
@@ -228,6 +248,7 @@ jobs:
           DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
           DEBUSINE_WORKSPACE: ${{ steps.build.outputs.workspace }}
+          DEBUSINE_TARGET_WORKSPACE: ${{ needs.resolve.outputs.debusine_target_workspace }}
           SRCPKG_NAME: ${{ needs.source-package.outputs.srcpkg_name }}
           SRCPKG_VERSION: ${{ needs.source-package.outputs.srcpkg_version }}
           SUITE: ${{ needs.resolve.outputs.suite }}
@@ -245,7 +266,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: --user root
-    environment: Production
+    environment: ${{ needs.resolve.outputs.environment }}
     permissions:
       contents: write
       deployments: write
@@ -273,6 +294,8 @@ jobs:
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE}}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
           DEBUSINE_CI_WORKSPACE: ${{ needs.build.outputs.workspace }}
+          DEBUSINE_TARGET_WORKSPACE: ${{ needs.resolve.outputs.debusine_target_workspace }}
+          PACKAGE_VERSION_IDENTIFIER: ${{ needs.resolve.outputs.package_version_identifier }}
           SRCPKG_NAME: ${{ needs.source-package.outputs.srcpkg_name }}
           SRCPKG_VERSION: ${{ needs.source-package.outputs.srcpkg_version}}
           SUITE: ${{ needs.resolve.outputs.suite }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,11 @@ the current `pkg-*` Debusine workflow model.
 - Source package artifacts are staged via a named `source-package/` directory
   artifact and restored in the build job before calling `lib/build`.
 - Branch-to-suite resolution is explicit in `resolve`:
-  - `qcom/debian/latest` -> `forky`
-  - `qcom/debian/trixie` -> `trixie`
+  - `qli/debian/latest`, `qli-staging/debian/latest`, or `qcom/debian/latest` (transitional) -> `forky`
+  - `qli/debian/trixie`, `qli-staging/debian/trixie`, or `qcom/debian/trixie` (transitional) -> `trixie`
+- Branch prefix also determines the package version string identifier:
+  - `qli/` or `qcom/` (transitional) -> `qli`
+  - `qli-staging/` -> `qli+staging`
 
 ## Important Active Contracts
 
@@ -99,7 +102,7 @@ Current intended placement:
 - default branch:
   - `debusine-daily.yml`
   - `debusine-pr-check.yml`
-- packaging branches (`qcom/debian/*`):
+- packaging branches (`qli/debian/*` or `qli-staging/debian/*`; `qcom/debian/*` also continues to be accepted for backwards compatibility during the transition):
   - `debusine-pr-hook.yml`
   - `debusine-release.yml`
 

--- a/lib/generate-step-summary
+++ b/lib/generate-step-summary
@@ -16,6 +16,7 @@ set -ex
 #   DEBUSINE_USER
 #   DEBUSINE_TOKEN
 #   DEBUSINE_WORKSPACE
+#   DEBUSINE_TARGET_WORKSPACE
 #   SRCPKG_NAME
 #   SRCPKG_VERSION
 #   SUITE
@@ -25,7 +26,7 @@ set -ex
 
 : ${GITHUB_STEP_SUMMARY:=/dev/null}
 
-qli_public_key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/qli/signing-keys.asc"|sed -e 's/^$/./;s/^/ /')
+target_public_key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${DEBUSINE_TARGET_WORKSPACE}/signing-keys.asc"|sed -e 's/^$/./;s/^/ /')
 ci_public_key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${DEBUSINE_WORKSPACE}/signing-keys.asc"|sed -e 's/^$/./;s/^/ /')
 
 cat > "$GITHUB_STEP_SUMMARY" <<END2
@@ -48,15 +49,15 @@ password <API token>
 END
 \`\`\`
 
-## Create \`qli.sources\` for baseline QLI apt repository access
+## Create \`${DEBUSINE_TARGET_WORKSPACE}.sources\` for baseline apt repository access
 \`\`\`
-sudo sh -c 'cat > /etc/apt/sources.list.d/qli.sources' <<END
+sudo sh -c 'cat > /etc/apt/sources.list.d/${DEBUSINE_TARGET_WORKSPACE}.sources' <<END
 Types: deb deb-src
-URIs: https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/qli/
+URIs: https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${DEBUSINE_TARGET_WORKSPACE}/
 Suites: ${SUITE}
 Components: main
 Signed-By:
-${qli_public_key}
+${target_public_key}
 END
 \`\`\`
 

--- a/lib/next_qcom_version.py
+++ b/lib/next_qcom_version.py
@@ -3,16 +3,20 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-"""Helpers for debchange-style qcom version increments.
+"""Helpers for debchange-style vendor version increments.
 
 Debian version strings have the form ``[epoch:]upstream_version[-debian_revision]``;
 see Debian Policy §5.6.12:
 https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-version
 
 This module implements the subset of ``debchange -i`` behaviour that is specific
-to Ubuntu vendor versioning, but replaces the substring ``ubuntu`` with
-``qcom``. The function operates on a full Debian package version string and
-returns the incremented version string.
+to Ubuntu vendor versioning, but replaces the substring ``ubuntu`` with a
+configurable identifier (default: ``qli``). The function operates on a full
+Debian package version string and returns the incremented version string.
+
+Migration: if the version already carries a legacy ``qcom`` suffix and the
+requested identifier differs, the ``qcom`` suffix is replaced by the new
+identifier and the version number is incremented rather than re-appended.
 """
 
 # Written by QGenie
@@ -26,24 +30,27 @@ _INCREMENTABLE_RE = re.compile(r"^(.*?)([a-yA-Y][a-zA-Z]*|\d+)([+~])?$", re.IGNO
 _NATIVE_QCOM_RE = re.compile(r"^(.*?)(\d+)$", re.IGNORECASE)
 
 
-def increment_qcom_version(version: str) -> str:
-    """Return the next debchange-style qcom version for ``version``.
+def increment_qcom_version(version: str, identifier: str = 'qli') -> str:
+    """Return the next debchange-style vendor version for ``version``.
 
     The behaviour matches the ``dch -i`` Ubuntu-specific path in
-    ``scripts/debchange.pl``, except that ``qcom`` is used where Ubuntu uses
-    ``ubuntu``:
+    ``scripts/debchange.pl``, except that ``identifier`` is used where Ubuntu
+    uses ``ubuntu``:
 
-    * if the version does not already end in a qcom/ppa derivative suffix,
-      append ``qcom1``;
+    * if the version does not already end in an identifier/ppa derivative
+      suffix, append ``<identifier>1``;
     * if the version carries a ``build`` suffix, drop that suffix before adding
-      ``qcom1``;
-    * for a native package ending in ``qcom`` with no trailing digit, bump the
-      numeric tail immediately before ``qcom`` and keep the ``qcom`` suffix;
+      ``<identifier>1``;
+    * for a native package ending in ``identifier`` (or legacy ``qcom``) with no
+      trailing digit, bump the numeric tail immediately before the suffix and
+      keep the suffix (migrating ``qcom`` to ``identifier`` if they differ);
     * otherwise, increment the final alphanumeric component the same way
-      ``dch -i`` does.
+      ``dch -i`` does, migrating a legacy ``qcom`` suffix to ``identifier``.
 
     Args:
         version: A Debian package version string.
+        identifier: The vendor identifier string to use (e.g. ``qli`` or
+            ``qli+staging``).
 
     Returns:
         The incremented Debian package version string.
@@ -51,8 +58,8 @@ def increment_qcom_version(version: str) -> str:
     Raises:
         ValueError: If the version cannot be parsed according to the subset of
             Debian version syntax handled here, or when the version has a
-            contradictory native/Non-native qcom form analogous to debchange's
-            fatal error.
+            contradictory native/Non-native identifier form analogous to
+            debchange's fatal error.
     """
     # Check for ~ppa versions - increment the debian revision before ~ppa
     ppa_match = re.match(r"^(.*?)(\d+)(~ppa.*)$", version)
@@ -76,38 +83,47 @@ def increment_qcom_version(version: str) -> str:
     extra = extra or ""
 
     # Validate that we have a reasonable version format
-    # Reject versions with ~ that aren't qcom/ppa related
-    if "~" in version and not re.search(r"(qcom|~ppa)", version):
-        raise ValueError(f"unable to parse Debian version: {version!r}")
-    
-    # Reject versions that don't look like valid Debian versions
-    # Must have at least one digit or be in a recognized format
-    if not re.search(r"\d", version) or (not re.search(r"[-.]", version) and not re.search(r"qcom|build", version)):
+    # Reject versions with ~ that aren't identifier/ppa related
+    if "~" in version and not re.search(rf"({re.escape(identifier)}|qcom|~ppa)", version):
         raise ValueError(f"unable to parse Debian version: {version!r}")
 
-    if not re.search(r"(qcom|~ppa)(\d+\.)*$", start):
-        build_match = re.match(r"(.*?)(qcom)?(\.?build)", start)
+    # Reject versions that don't look like valid Debian versions
+    # Must have at least one digit or be in a recognized format
+    if not re.search(r"\d", version) or (not re.search(r"[-.]", version) and not re.search(rf"{re.escape(identifier)}|qcom|build", version)):
+        raise ValueError(f"unable to parse Debian version: {version!r}")
+
+    # "already versioned" pattern: matches new identifier, or legacy qcom
+    already_versioned_re = rf"({re.escape(identifier)}|qcom|~ppa)(\d+\.)*$"
+    if not re.search(already_versioned_re, start):
+        build_id_pattern = f"(?:{re.escape(identifier)}|qcom)"
+        build_match = re.match(rf"(.*?)({build_id_pattern})?(\.?build)", start)
         if build_match:
             start = build_match.group(1)
             end = build_match.group(2) or ""
 
-        if end.startswith("qcom"):
+        known_end = end in (identifier, 'qcom')
+        if known_end:
             native_match = _NATIVE_QCOM_RE.match(start)
             if not native_match:
                 raise ValueError(
-                    f"native qcom version is missing the numeric part before "
-                    f"'qcom': {version!r}"
+                    f"native vendor version is missing the numeric part before "
+                    f"the identifier: {version!r}"
                 )
             if "-" in version:
                 raise ValueError(
-                    "version suffix indicates native qcom package, but the "
+                    "version suffix indicates native vendor package, but the "
                     "included '-' suggests the contrary"
                 )
             version_head, version_tail = native_match.groups()
             start = f"{version_head}{int(version_tail) + 1}"
+            # Migrate legacy qcom to new identifier
+            end = identifier
         else:
-            end = f"{end}qcom1"
+            end = f"{end}{identifier}1"
     else:
+        # Migrate legacy qcom suffix to new identifier before incrementing
+        if identifier != 'qcom' and re.search(r"qcom(\d+\.)*$", start):
+            start = re.sub(r"qcom$", identifier, start)
         if end.isdigit():
             end = str(int(end) + 1)
         else:
@@ -116,4 +132,5 @@ def increment_qcom_version(version: str) -> str:
     return f"{start}{end}{extra}"
 
 if __name__ == '__main__':
-    print(increment_qcom_version(sys.argv[1]))
+    ident = sys.argv[2] if len(sys.argv) > 2 else 'qli'
+    print(increment_qcom_version(sys.argv[1], ident))

--- a/lib/next_qcom_version_test.py
+++ b/lib/next_qcom_version_test.py
@@ -1,4 +1,4 @@
-"""pytest coverage for debchange-style qcom version increments."""
+"""pytest coverage for debchange-style vendor version increments."""
 
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -10,27 +10,46 @@ from next_qcom_version import increment_qcom_version
 # Written by QGenie
 
 @pytest.mark.parametrize(
-    ("version", "expected"),
+    ("version", "identifier", "expected"),
     [
-        ("1.2-3", "1.2-3qcom1"),
-        ("2:1.2-3", "2:1.2-3qcom1"),
-        ("1.2", "1.2qcom1"),
-        ("1.2qcom1", "1.2qcom2"),
-        ("1.2-3qcom1", "1.2-3qcom2"),
-        ("1.2-3qcom9", "1.2-3qcom10"),
-        ("1.2-3qcom1~", "1.2-3qcom2~"),
-        ("1.2-3qcom1+", "1.2-3qcom2+"),
-        ("1.2-3~ppa1", "1.2-4~ppa1"),
-        ("1.2-3~ppa1.1", "1.2-4~ppa1.1"),
-        ("1.2build1", "1.2qcom1"),
-        ("1.2qcombuild1", "1.3qcom"),
-        ("1.2qcom", "1.3qcom"),
-        ("1.0.7qcom10~bpo1", "1.0.7qcom10~bpo2"),
+        # --- qli identifier (standard) ---
+        ("1.2-3", "qli", "1.2-3qli1"),
+        ("2:1.2-3", "qli", "2:1.2-3qli1"),
+        ("1.2", "qli", "1.2qli1"),
+        ("1.2qli1", "qli", "1.2qli2"),
+        ("1.2-3qli1", "qli", "1.2-3qli2"),
+        ("1.2-3qli9", "qli", "1.2-3qli10"),
+        ("1.2-3qli1~", "qli", "1.2-3qli2~"),
+        ("1.2-3qli1+", "qli", "1.2-3qli2+"),
+        ("1.2-3~ppa1", "qli", "1.2-4~ppa1"),
+        ("1.2-3~ppa1.1", "qli", "1.2-4~ppa1.1"),
+        ("1.2build1", "qli", "1.2qli1"),
+        ("1.2qlibuild1", "qli", "1.3qli"),
+        ("1.2qli", "qli", "1.3qli"),
+        ("1.0.7qli10~bpo1", "qli", "1.0.7qli10~bpo2"),
+        # --- qcom migration: qcom suffix replaced by qli ---
+        ("1.2qcom1", "qli", "1.2qli2"),
+        ("1.2-3qcom1", "qli", "1.2-3qli2"),
+        ("1.2-3qcom9", "qli", "1.2-3qli10"),
+        ("1.2qcom", "qli", "1.3qli"),
+        ("1.2qcombuild1", "qli", "1.3qli"),
+        # --- qli+staging identifier ---
+        ("1.2-3", "qli+staging", "1.2-3qli+staging1"),
+        ("1.2-3qli+staging1", "qli+staging", "1.2-3qli+staging2"),
+        ("1.2-3qli+staging9", "qli+staging", "1.2-3qli+staging10"),
+        ("1.2", "qli+staging", "1.2qli+staging1"),
+        # --- qcom identifier: backward-compat ---
+        ("1.2-3", "qcom", "1.2-3qcom1"),
+        ("1.2qcom1", "qcom", "1.2qcom2"),
+        ("1.2-3qcom1", "qcom", "1.2-3qcom2"),
+        ("1.2qcom", "qcom", "1.3qcom"),
+        ("1.2build1", "qcom", "1.2qcom1"),
+        ("1.2qcombuild1", "qcom", "1.3qcom"),
     ],
 )
-def test_increment_qcom_version(version: str, expected: str) -> None:
-    """Increment versions the same way dch -i does for Ubuntu, but with qcom."""
-    assert increment_qcom_version(version) == expected
+def test_increment_qcom_version(version: str, identifier: str, expected: str) -> None:
+    """Increment versions the same way dch -i does for Ubuntu, but with identifier."""
+    assert increment_qcom_version(version, identifier) == expected
 
 
 @pytest.mark.parametrize(
@@ -44,4 +63,4 @@ def test_increment_qcom_version(version: str, expected: str) -> None:
 def test_increment_qcom_version_rejects_invalid_inputs(version: str) -> None:
     """Reject versions outside the supported debchange-derived cases."""
     with pytest.raises(ValueError):
-        increment_qcom_version(version)
+        increment_qcom_version(version, 'qli')

--- a/lib/prepare-release
+++ b/lib/prepare-release
@@ -14,6 +14,7 @@ set -ex
 
 # Inputs:
 #   $SUITE
+#   $DEBUSINE_TARGET_WORKSPACE
 #   Checked out source tree in $PWD/srcpkg
 
 # Outputs:
@@ -23,6 +24,11 @@ set -ex
 tmpdir=$(mktemp -d)
 cleanup() { rm -rf "$tmpdir"; }
 trap cleanup EXIT
+
+if [ -z "${DEBUSINE_TARGET_WORKSPACE:-}" ]; then
+    echo "DEBUSINE_TARGET_WORKSPACE is not set" >&2
+    exit 1
+fi
 
 cd srcpkg
 
@@ -47,7 +53,7 @@ export GIT_AUTHOR_NAME="Release Bot"
 export GIT_AUTHOR_EMAIL="noreply@example.com"
 export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
-git commit -m"d/changelog: release $final_release_version" debian/changelog
+git commit -m"d/changelog: release $final_release_version to $DEBUSINE_TARGET_WORKSPACE" debian/changelog
 
-gbp tag --ignore-branch --debian-tag='qcom/debian/%(version)s' --posttag='echo $GBP_TAG > '"$tmpdir/release-tag"
+gbp tag --ignore-branch --debian-tag="${DEBUSINE_TARGET_WORKSPACE}/debian/%(version)s" --posttag='echo $GBP_TAG > '"$tmpdir/release-tag"
 git bundle create ../release.bundle "HEAD^..refs/tags/$(cat "$tmpdir/release-tag")"

--- a/lib/push-release
+++ b/lib/push-release
@@ -31,7 +31,8 @@ if [ "$(dpkg-parsechangelog -SDistribution)" = "UNRELEASED" ]; then
 fi
 
 previous_version=$(dpkg-parsechangelog -SVersion)
-next_version=$(../debusine-action/lib/next_qcom_version "$previous_version")
+pkg_version_id="${PACKAGE_VERSION_IDENTIFIER:-qcom}"
+next_version=$(../debusine-action/lib/next_qcom_version "$previous_version" "$pkg_version_id")
 case "$next_version" in
     *~) next_dev_version="$next_version" ;;
     *) next_dev_version="${next_version}~" ;;

--- a/lib/release
+++ b/lib/release
@@ -19,7 +19,7 @@ set -o pipefail
 #   DEBUSINE_SCOPE
 #   DEBUSINE_TOKEN
 #   DEBUSINE_CI_WORKSPACE
-#   DEBUSINE_TARGET_WORKSPACE (optional, defaults to qli)
+#   DEBUSINE_TARGET_WORKSPACE (optional, defaults to qli-staging)
 #   SRCPKG_NAME
 #   SRCPKG_VERSION
 #   SUITE
@@ -27,7 +27,7 @@ set -o pipefail
 # Outputs:
 #   None
 
-target_workspace=${DEBUSINE_TARGET_WORKSPACE:-qli}
+target_workspace=${DEBUSINE_TARGET_WORKSPACE:-qli-staging}
 
 echo "::group::Release to Debusine ${target_workspace}"
 

--- a/lib/release
+++ b/lib/release
@@ -60,6 +60,7 @@ binary_artifacts:
   category: debian:binary-package
   collection: ${suite_id}@collections
 target_suite: ${SUITE}@debian:suite
+unembargo: true
 END
 )
 echo "Workflow start output: $workflow_start_output" >&2

--- a/packaging-workflows/README.md
+++ b/packaging-workflows/README.md
@@ -2,7 +2,8 @@ This is a set of four workflows that should be imported into each pkg-*
 repository to enable Debusine CI. `debusine-daily.yml` and
 `debusine-pr-check.yml` belong in the default branch. `debusine-pr-hook.yml`
 and `debusine-release.yml` must also be copied to each enabled packaging
-(`qcom/debian/*`) branch. `README.debusine.md` should also be copied into
+(`qli/debian/*`, `qli-staging/debian/*`, or `qcom/debian/*` during transition)
+branch. `README.debusine.md` should also be copied into
 `.github/workflows/` in each branch touched to help future maintainers.
 
 When these files are updated, they must also updated in every "managed" pkg-*

--- a/packaging-workflows/debusine-daily.yml
+++ b/packaging-workflows/debusine-daily.yml
@@ -24,8 +24,8 @@ jobs:
       - id: set-matrix
         name: Set matrix
         run: |
-          # Define candidate branches (duplicated from workflow_dispatch options in debusine.yml)
-          candidates='["qcom/debian/latest", "qcom/debian/trixie"]'
+          # Define candidate branches
+          candidates='["qli/debian/latest", "qli/debian/trixie", "qli-staging/debian/latest", "qli-staging/debian/trixie", "qcom/debian/latest", "qcom/debian/trixie"]'
 
           # Filter to branches that exist
           existing=()

--- a/packaging-workflows/debusine-pr-hook.yml
+++ b/packaging-workflows/debusine-pr-hook.yml
@@ -11,6 +11,8 @@ name: Debusine PR Hook
 on:
   pull_request:
     branches:
+      - 'qli/debian/**'
+      - 'qli-staging/debian/**'
       - 'qcom/debian/**'
 
 permissions:

--- a/packaging-workflows/debusine-release.yml
+++ b/packaging-workflows/debusine-release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   debusine:
     name: Debusine
-    if: startsWith(github.ref_name, 'qcom/debian/')
+    if: startsWith(github.ref_name, 'qli/debian/') || startsWith(github.ref_name, 'qli-staging/debian/') || startsWith(github.ref_name, 'qcom/debian/')
     uses: qualcomm-linux/debusine-action/.github/workflows/debusine.yml@main
     with:
       target_branch: ${{ github.ref_name }}


### PR DESCRIPTION
Add support for releasing to a qli-staging Debusine workspace as an alternative to qli, and rename packaging branches from the qcom/ prefix to a workspace-named prefix accordingly. This is now done mostly generically with a lookup table in the reusable workflow, opening the door to further workspaces in the future.

During the development of this change, the qli and qli-staging workspaces got created and both made public. This then required "unembargo" to be specified, so I bundled that in a separate commit in this PR.

Out of scope of this PR:

* The branch renames themselves. We will instead ensure that these are correct as we rename the repositories, which is easier than establishing automation here that will only be used for a one-off set of renames.
* Adjustment of gbp.conf and changelog version over the branch renames. Again, this would only be used once for a one-off set of renames.
* Consequently, I've skipped precise handling of next_qcom_version over branch renames. However some basic handling is done. I've focused on the test suite to ensure that it'll do what we require, rather than worrying about the implementation too much for what is just a very deterministic string processor.

Things I'm not doing in this PR, but need to do later:

* Handling of the build dependency from qli-staging to qli. This is mostly on the Debusine end and not needed in these workflows, except that the output UI telling users how to enable apt in sources.list.d needs to follow the build dependencies used. Ideally we'd find them by walking Debusine's configured build dependencies automatically, but that seems quite tricky (I'm not sure the right things are really exposed). Maybe it's quicker to do this by hand as an exception for qli-staging for now. But this doesn't make sense until the build dependency is in place, and we can probably get away without it for now.

* The environment names are "Production" and "Staging". Maybe these should be "qli" and "qli-staging" to properly open the door to others. Maybe we won't need a 1:1 mapping between GitHub Environment and Debusine Workspace. It's unclear. For now, I've left it, since the environments can be renamed without really affecting anything else later. Repositories would be reconfigured automatically by my script (to land later, not in this PR) and pkg-* repositories wouldn't otherwise require any changes. So this is straightforward to do later once we have a suitable design.