### PR TITLE
Update Stale PR Workflow: Auto-close after 30+5 days

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/stale@v10
       with:
-        stale-issue-message: 'Remove the stale label or add a comment to reset the inactivity timer.'
-        stale-pr-message: 'Remove the stale label or add a comment to reset the inactivity timer'
+        stale-issue-message: 'This issue has been marked as stale due to 30 days of inactivity and will automatically close after an additional 5 days. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
+        stale-pr-message: 'This pull request has been marked as stale due to 30 days of inactivity and will automatically close after an additional 5 days. To prevent automatic closure in 5 days, remove the stale label or add a comment. You can reopen a closed pull  request at any time.'
         days-before-stale: 30
-        days-before-close: -1
+        days-before-close: 5
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
Update Stale PR Workflow: Auto-close after 30+5 days Updates the Stale GitHub Actions workflow to mark PRs and issues as stale after 30 days of inactivity and automatically close them after an additional 5 days. This aligns with PdM's request to ensure stale PRs and issues that may no longer be needed are closed, making it easier to track progress and milestones.