### PR TITLE
debusine: prevent artifact collisions on dailies

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Upload source package files
         uses: actions/upload-artifact@v7
         with:
-          name: source-package
+          name: source-package-${{ inputs.job_index }}
           path: source-package
           if-no-files-found: error
 
@@ -186,7 +186,7 @@ jobs:
         if: ${{ inputs.release }}
         uses: actions/upload-artifact@v7
         with:
-          name: release-bundle
+          name: release-bundle-${{ inputs.job_index }}
           path: release.bundle
           if-no-files-found: error
 
@@ -215,7 +215,7 @@ jobs:
       - name: Download source package files
         uses: actions/download-artifact@v8
         with:
-          name: source-package
+          name: source-package-${{ inputs.job_index }}
           path: source-package
 
       - name: Restore source package files to workspace root
@@ -286,7 +286,7 @@ jobs:
       - name: Download release bundle
         uses: actions/download-artifact@v8
         with:
-          name: release-bundle
+          name: release-bundle-${{ inputs.job_index }}
           path: .
       - name: Release
         env:


### PR DESCRIPTION
When the daily workflow expands a matrix over multiple target branches,
each branch triggers a separate call to the reusable debusine.yml
workflow within the same parent run. All reusable-workflow calls share
the same artifact namespace, so both source-package jobs were uploading
artifacts named "source-package" (and "release-bundle"). GitHub creates
distinct artifacts for each upload but gives them the same name; the
subsequent download-artifact step then picks up whichever it finds
first, which may belong to a different matrix expansion.

Fix by appending -${{ inputs.job_index }} to every artifact name. The
daily caller already passes strategy.job-index (the matrix expansion
index) as job_index, so each expansion now produces uniquely named
artifacts that are downloaded by the correct build/release job.
