### PR TITLE
watch-allowlist: add pkg-qcom-sensors on trixie

### DIFF
--- a/lib/watch-allowlist/dacda0b7521861ce740804919ef584cab4dc5856b243f4ace86770cc5876b06f
+++ b/lib/watch-allowlist/dacda0b7521861ce740804919ef584cab4dc5856b243f4ace86770cc5876b06f
@@ -1,0 +1,19 @@
+version=4
+# There currently are multiple "software package" releases for the 1.0.2 version:
+#
+# - 260514.1
+# - 260512
+# - 260511.2
+# - 260512
+#
+# Pick the currently-known last one (260514.1) and force it as an upstream.
+#
+# Note that we are matching the `qcom-sensors-core*` tarball for finding out
+# the upstream version, as the upstream tarball seems to always be named
+# `sensors-prebuilts.tar.gz` without any versioning information.
+#
+opts=searchmode=plain,\
+downloadurlmangle=s%/api/storage/qsc_releases-cache/%/qsc_releases/%;s%qcom-sensors-core_@ANY_VERSION@_arm64.tar.gz%sensors-prebuilts.tar.gz%,\
+filenamemangle=s/qcom-sensors-core/qcom-sensors/ \
+https://qartifactory-edge.qualcomm.com/artifactory/api/search/artifact?name=qcom-sensors-core \
+https://qartifactory-edge.qualcomm.com/artifactory/api/storage/qsc_releases-cache/software/chip/component/sensors.lnx.0.0/260514.1/prebuilt_trixie/qcom-sensors-core_@ANY_VERSION@_arm64.tar.gz


### PR DESCRIPTION
Add watch allowlist entry for pkg-qcom-sensors against trixie.
