### PR TITLE
Build depend across workspaces

### DIFF
--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -235,6 +235,7 @@ jobs:
           DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+          DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
           DEBUSINE_PARENT_WORKSPACE: ${{ inputs.debusine-parent-workspace }}
           EXTRA_BUILD_DEP_WORKSPACES: ${{ needs.resolve.outputs.extra_build_dep_workspaces }}
         run: |

--- a/.github/workflows/debusine.yml
+++ b/.github/workflows/debusine.yml
@@ -62,6 +62,7 @@ jobs:
       debusine_target_workspace: ${{ steps.map_suite.outputs.debusine_target_workspace }}
       package_version_identifier: ${{ steps.map_suite.outputs.package_version_identifier }}
       environment: ${{ steps.map_suite.outputs.environment }}
+      extra_build_dep_workspaces: ${{ steps.map_suite.outputs.extra_build_dep_workspaces }}
     steps:
       - id: map_suite
         name: Map branch to suite
@@ -76,9 +77,9 @@ jobs:
             };
 
             const prefixMap = [
-              { prefix: 'qli-staging/', workspace: 'qli-staging', identifier: 'qli+staging', environment: 'Staging'    },
-              { prefix: 'qli/',         workspace: 'qli',          identifier: 'qli',         environment: 'Production' },
-              { prefix: 'qcom/',        workspace: 'qli',          identifier: 'qli',         environment: 'Production' },
+              { prefix: 'qli-staging/', workspace: 'qli-staging', identifier: 'qli+staging', environment: 'Staging',    extra_build_dep_workspaces: ['qli', 'qli-staging'] },
+              { prefix: 'qli/',         workspace: 'qli',          identifier: 'qli',         environment: 'Production', extra_build_dep_workspaces: ['qli'] },
+              { prefix: 'qcom/',        workspace: 'qli',          identifier: 'qli',         environment: 'Production', extra_build_dep_workspaces: ['qli'] },
             ];
 
             const targetBranch = process.env.TARGET_BRANCH;
@@ -100,6 +101,7 @@ jobs:
             core.setOutput('debusine_target_workspace', workspace);
             core.setOutput('package_version_identifier', identifier);
             core.setOutput('environment', prefixEntry.environment);
+            core.setOutput('extra_build_dep_workspaces', prefixEntry.extra_build_dep_workspaces.join(' '));
             core.info(`Mapped branch '${targetBranch}' to suite '${suite}', workspace '${workspace}', identifier '${identifier}', environment '${prefixEntry.environment}'`);
       - id: determine_checkout_ref
         name: Determine the ref of the packaging to build
@@ -234,6 +236,7 @@ jobs:
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
           DEBUSINE_PARENT_WORKSPACE: ${{ inputs.debusine-parent-workspace }}
+          EXTRA_BUILD_DEP_WORKSPACES: ${{ needs.resolve.outputs.extra_build_dep_workspaces }}
         run: |
           set -ex
           debusine-action/lib/build

--- a/lib/build
+++ b/lib/build
@@ -20,6 +20,7 @@ set -o pipefail
 #   JOB_INDEX
 #   DEBUSINE_HOST
 #   DEBUSINE_SCOPE
+#   DEBUSINE_USER (required for extra_repositories workaround)
 #   DEBUSINE_TOKEN
 #   DEBUSINE_PARENT_WORKSPACE (optional, defaults to qli-ci)
 #   SUITE
@@ -30,6 +31,38 @@ set -o pipefail
 #   Output file `output` suitable for $GITHUB_OUTPUT containing `workspace`
 
 echo "::group::Build in Debusine"
+
+# WORKAROUND: older production Debusine does not support the suite lookup syntax
+# (//workspace=...) in extra_repositories. Convert each such entry to the external
+# repository form. Drop this function and its single caller when the production
+# instance is updated.
+apply_extra_repositories_workaround() {
+    local yaml_file="$1"
+    [ -n "${EXTRA_BUILD_DEP_WORKSPACES:-}" ] || return 0
+    local tmpfile ws indent key
+    tmpfile=$(mktemp)
+    while IFS= read -r line; do
+        if printf '%s' "$line" | grep -qE '^ +- suite: //workspace='; then
+            ws=$(printf '%s' "$line" | sed 's|.*//workspace=\([^/]*\)/.*|\1|')
+            indent=$(printf '%s' "$line" | sed 's/^\( *\)- suite:.*/\1/')
+            key=$(curl -fsSu "${DEBUSINE_USER}:${DEBUSINE_TOKEN}" \
+                "https://deb.${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${ws}/signing-keys.asc") \
+                || { rm -f "$tmpfile"; return 1; }
+            printf '%s- url: https://deb.%s/%s/%s/\n' "$indent" "$DEBUSINE_HOST" "$DEBUSINE_SCOPE" "$ws"
+            printf '%s  suite: %s\n' "$indent" "$SUITE"
+            printf '%s  components:\n' "$indent"
+            printf '%s    - main\n' "$indent"
+            printf '%s    - contrib\n' "$indent"
+            printf '%s    - non-free\n' "$indent"
+            printf '%s    - non-free-firmware\n' "$indent"
+            printf '%s  signing_key: |\n' "$indent"
+            printf '%s\n' "$key" | sed "s/^/${indent}    /"
+        else
+            printf '%s\n' "$line"
+        fi
+    done < "$yaml_file" > "$tmpfile"
+    mv "$tmpfile" "$yaml_file"
+}
 
 parent_workspace=${DEBUSINE_PARENT_WORKSPACE:-qli-ci}
 child_ci_suffix=gh-${GITHUB_REPOSITORY_ID:-0}-${GITHUB_RUN_ID:-0}-${GITHUB_RUN_ATTEMPT:-0}-${JOB_INDEX:-0}
@@ -77,6 +110,7 @@ cat >> "$_template_yaml" <<END
 runtime_parameters:
   source_artifact: any
 END
+apply_extra_repositories_workaround "$_template_yaml"
 debusine workflow-template create debian_pipeline debian-pipeline < "$_template_yaml"
 rm "$_template_yaml"
 artifact_import_output=$(debusine artifact import-debian --yaml *.dsc)

--- a/lib/build
+++ b/lib/build
@@ -23,6 +23,7 @@ set -o pipefail
 #   DEBUSINE_TOKEN
 #   DEBUSINE_PARENT_WORKSPACE (optional, defaults to qli-ci)
 #   SUITE
+#   EXTRA_BUILD_DEP_WORKSPACES (optional, space-separated workspace names to add as extra_repositories)
 #   .dsc file in current directory
 
 # Outputs:
@@ -52,7 +53,8 @@ echo "Workflow start output: $workflow_start_output" >&2
 workflow_id=$(echo "$workflow_start_output"|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
 debusine archive suite create --architecture all --architecture amd64 --architecture arm64 ${SUITE}
-debusine workflow-template create debian_pipeline debian-pipeline <<END
+_template_yaml=$(mktemp)
+cat > "$_template_yaml" <<END
 static_parameters:
   vendor: debian
   sbuild_environment_variant: buildd
@@ -64,9 +66,19 @@ static_parameters:
   enable_blhc: false
   codename: $SUITE
   suite: $SUITE@debian:suite
+END
+if [ -n "${EXTRA_BUILD_DEP_WORKSPACES:-}" ]; then
+    echo "  extra_repositories:" >> "$_template_yaml"
+    for _ws in $EXTRA_BUILD_DEP_WORKSPACES; do
+        echo "    - suite: //workspace=${_ws}/${SUITE}@debian:suite" >> "$_template_yaml"
+    done
+fi
+cat >> "$_template_yaml" <<END
 runtime_parameters:
   source_artifact: any
 END
+debusine workflow-template create debian_pipeline debian-pipeline < "$_template_yaml"
+rm "$_template_yaml"
 artifact_import_output=$(debusine artifact import-debian --yaml *.dsc)
 echo "Artifact import output: $artifact_import_output" >&2
 artifact_id=$(echo "$artifact_import_output"|yq -r .artifact_id)


### PR DESCRIPTION
Since we build packages from CI in their own ephemeral workspaces, they should fulfil build dependencies from where they intend to land once released, so that we can build up a stack of packages in CI that build depend on each other.

To implement this we add this to our branch map. The branch name already determines the target workspace, and this adds knowledge of what the corresponding build dependencies should be. When qli is the target, qli is the only build dependency. This ensures that users adding qli only have to add qli.

When qli-staging is the target, both qli-staging and qli are build dependencies. Packages in qli-staging are intended to reach qli eventually. This allows for packages to be prepared in qli-staging while build depending on their final target, and avoids us having to copy packages from qli to qli-staging to make that workflow work.
