### PR TITLE
Fix ~bpo version increment to bump local counter

### DIFF
--- a/lib/next_qcom_version.py
+++ b/lib/next_qcom_version.py
@@ -68,12 +68,13 @@ def increment_qcom_version(version: str, identifier: str = 'qli') -> str:
         prefix, debian_rev, ppa_suffix = ppa_match.groups()
         return f"{prefix}{int(debian_rev) + 1}{ppa_suffix}"
 
-    # Check for ~bpo versions - increment the bpo number
-    bpo_match = re.match(r"^(.*?)(~bpo)(\d+)(.*)$", version)
+    # Check for ~bpo versions: ~bpoN+M increments M; ~bpoN increments N
+    bpo_match = re.match(r"^(.*?~bpo)(\d+)(\+(\d+))?$", version)
     if bpo_match:
-        # For ~bpo versions, increment the number after bpo
-        prefix, bpo_type, bpo_num, suffix = bpo_match.groups()
-        return f"{prefix}{bpo_type}{int(bpo_num) + 1}{suffix}"
+        prefix, bpo_num, plus_group, local_num = bpo_match.groups()
+        if local_num is not None:
+            return f"{prefix}{bpo_num}+{int(local_num) + 1}"
+        return f"{prefix}{int(bpo_num) + 1}"
 
     match = _INCREMENTABLE_RE.match(version)
     if not match:

--- a/lib/next_qcom_version_test.py
+++ b/lib/next_qcom_version_test.py
@@ -27,6 +27,12 @@ from next_qcom_version import increment_qcom_version
         ("1.2qlibuild1", "qli", "1.3qli"),
         ("1.2qli", "qli", "1.3qli"),
         ("1.0.7qli10~bpo1", "qli", "1.0.7qli10~bpo2"),
+        pytest.param(
+            "1.0.19+ds-0qli3~bpo13+1",
+            "qli",
+            "1.0.19+ds-0qli3~bpo13+2",
+            marks=pytest.mark.xfail(reason="Issue #52"),
+        ),
         # --- qcom migration: qcom suffix replaced by qli ---
         ("1.2qcom1", "qli", "1.2qli2"),
         ("1.2-3qcom1", "qli", "1.2-3qli2"),

--- a/lib/next_qcom_version_test.py
+++ b/lib/next_qcom_version_test.py
@@ -27,12 +27,7 @@ from next_qcom_version import increment_qcom_version
         ("1.2qlibuild1", "qli", "1.3qli"),
         ("1.2qli", "qli", "1.3qli"),
         ("1.0.7qli10~bpo1", "qli", "1.0.7qli10~bpo2"),
-        pytest.param(
-            "1.0.19+ds-0qli3~bpo13+1",
-            "qli",
-            "1.0.19+ds-0qli3~bpo13+2",
-            marks=pytest.mark.xfail(reason="Issue #52"),
-        ),
+        ("1.0.19+ds-0qli3~bpo13+1", "qli", "1.0.19+ds-0qli3~bpo13+2"),
         # --- qcom migration: qcom suffix replaced by qli ---
         ("1.2qcom1", "qli", "1.2qli2"),
         ("1.2-3qcom1", "qli", "1.2-3qli2"),


### PR DESCRIPTION
The ~bpo handler was treating the trailing +M as an opaque suffix and incrementing N instead. For a version like ~bpo13+1 the result was ~bpo14+1 rather than the correct ~bpo13+2.

Rewrite the regex to capture the optional +M group explicitly and increment M when present, falling back to incrementing N for the plain ~bpoN form.

Fixes: #52
