### PR TITLE
Add components to ephemeral workspaces

### DIFF
--- a/lib/build
+++ b/lib/build
@@ -85,7 +85,15 @@ workflow_start_output=$(echo "suffix: $child_ci_suffix"|debusine workflow start 
 echo "Workflow start output: $workflow_start_output" >&2
 workflow_id=$(echo "$workflow_start_output"|yq -r .id)
 debusine-action/lib/poll_workflow.py "$workflow_id"
-debusine archive suite create --architecture all --architecture amd64 --architecture arm64 ${SUITE}
+debusine archive suite create \
+    --architecture all \
+    --architecture amd64 \
+    --architecture arm64 \
+    --component main \
+    --component contrib \
+    --component non-free \
+    --component non-free-firmware \
+    ${SUITE}
 _template_yaml=$(mktemp)
 cat > "$_template_yaml" <<END
 static_parameters:


### PR DESCRIPTION
Ephemeral workspaces should have all four components (main, contrib, non-free, non-free-firmware) present, so that their corresponding apt repositories publish those components should they be used.
